### PR TITLE
Add rust tools to example

### DIFF
--- a/bazel_env.bzl
+++ b/bazel_env.bzl
@@ -9,10 +9,11 @@ def _rlocation_path(ctx, file):
 
 def _heuristic_rlocation_path(ctx, path):
     # type: (ctx, string) -> string
+    if path.startswith("bazel-out/"):
+        path = path[path.find("external/"):]
+
     if path.startswith("external/"):
         return path.removeprefix("external/")
-    elif path.startswith("bazel-out/"):
-        return path[path.find("external/") + len("external/"):]
     elif path.startswith("../"):
         return path[3:]
     elif path.startswith("/"):

--- a/bazel_env.bzl
+++ b/bazel_env.bzl
@@ -11,6 +11,8 @@ def _heuristic_rlocation_path(ctx, path):
     # type: (ctx, string) -> string
     if path.startswith("external/"):
         return path.removeprefix("external/")
+    elif path.startswith("bazel-out/"):
+        return path[path.find("external/") + len("external/"):]
     elif path.startswith("../"):
         return path[3:]
     elif path.startswith("/"):

--- a/bazel_env.bzl
+++ b/bazel_env.bzl
@@ -10,7 +10,8 @@ def _rlocation_path(ctx, file):
 def _heuristic_rlocation_path(ctx, path):
     # type: (ctx, string) -> string
     if path.startswith("bazel-out/"):
-        path = path[path.find("external/"):]
+        # Skip over bazel-out/<cfg>/bin.
+        path = "/".join(path.split("/")[3:])
 
     if path.startswith("external/"):
         return path.removeprefix("external/")

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@buildozer//:buildozer.bzl", "BUILDOZER_LABEL")
-load("@bazel_env.bzl", "bazel_env")
 load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@bazel_env.bzl", "bazel_env")
 load(":test_helpers.bzl", "REPO_NAME_SEPARATOR")
 
 # `bazel run //:bazel_env` prints a summary and setup steps.
@@ -11,6 +11,7 @@ bazel_env(
         "jdk": "@rules_java//toolchains:current_host_java_runtime",
         "python": "@rules_python//python:current_py_toolchain",
         "nodejs": "@nodejs_toolchains//:resolved_toolchain",
+        "rust": "@rules_rust//rust/toolchain:current_rust_toolchain",
     },
     tools = {
         # Tool paths can reference the Make variables provided by toolchains.
@@ -26,6 +27,10 @@ bazel_env(
         "pnpm": "@pnpm",
         "python": "$(PYTHON3)",
         "python_tool": ":python_tool",
+        "cargo": "$(CARGO)",
+        "rustfmt": "$(RUSTFMT)",
+        "rustc": "$(RUSTC)",
+        "rustdoc": "$(RUSTDOC)",
     },
 )
 

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -45,7 +45,11 @@ python.toolchain(
 )
 
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
-rust.toolchain(edition = "2021")
+rust.toolchain(
+    edition = "2021",
+    rustfmt_version = "1.80.0",
+    versions = ["1.80.0"],
+)
 use_repo(rust, "rust_toolchains")
 
 register_toolchains("@rust_toolchains//:all")

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -16,6 +16,7 @@ bazel_dep(name = "rules_go", version = "0.47.1")
 bazel_dep(name = "rules_java", version = "7.6.4")
 bazel_dep(name = "rules_nodejs", version = "6.1.1")
 bazel_dep(name = "rules_python", version = "0.32.2")
+bazel_dep(name = "rules_rust", version = "0.49.3")
 bazel_dep(name = "platforms", version = "0.0.10")
 
 # Don't update the versions below, they are only used to verify the hermeticity of bazel_env.
@@ -42,6 +43,12 @@ python.toolchain(
     is_default = True,
     python_version = "3.11.8",
 )
+
+rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
+rust.toolchain(edition = "2021")
+use_repo(rust, "rust_toolchains")
+
+register_toolchains("@rust_toolchains//:all")
 
 http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 

--- a/examples/bazel_env_test.sh
+++ b/examples/bazel_env_test.sh
@@ -122,9 +122,15 @@ assert_cmd_output "pnpm --version" "8.6.7"
 assert_cmd_output "python --version" "Python 3.11.8"
 # Bazel's Python launcher requires a system installation of python3.
 assert_cmd_output "python_tool" "python_tool version 0.0.1" ":$(dirname "$(which python3)")"
+assert_cmd_output "cargo --version" "cargo 1.80.0 (376290515 2024-07-16)"
+assert_cmd_output "rustc --version" "rustc 1.80.0 (051478957 2024-07-21)"
+assert_cmd_output "rustfmt --version" "rustfmt 1.7.0-stable (05147895 2024-07-21)"
+assert_cmd_output "rustdoc --version" "rustdoc 1.80.0 (051478957 2024-07-21)"
 
 #### Toolchains ####
 
 [[ -d "$build_workspace_directory/bazel-out/bazel_env-opt/bin/bazel_env/toolchains/cc_toolchain" ]]
 assert_cmd_output "$build_workspace_directory/bazel-out/bazel_env-opt/bin/bazel_env/toolchains/jdk/bin/java --version" "openjdk 17.0.11 2024-04-16 LTS"
 assert_cmd_output "$build_workspace_directory/bazel-out/bazel_env-opt/bin/bazel_env/toolchains/python/bin/python3 --version" "Python 3.11.8"
+assert_cmd_output "$build_workspace_directory/bazel-out/bazel_env-opt/bin/bazel_env/toolchains/rust/bin/cargo --version" "cargo 1.80.0 (376290515 2024-07-16)"
+assert_cmd_output "$build_workspace_directory/bazel-out/bazel_env-opt/bin/bazel_env/toolchains/rust/bin/rustc --version" "rustc 1.80.0 (051478957 2024-07-21)"

--- a/examples/bazel_env_test.sh
+++ b/examples/bazel_env_test.sh
@@ -124,7 +124,7 @@ assert_cmd_output "python --version" "Python 3.11.8"
 assert_cmd_output "python_tool" "python_tool version 0.0.1" ":$(dirname "$(which python3)")"
 assert_cmd_output "cargo --version" "cargo 1.80.0 (376290515 2024-07-16)"
 assert_cmd_output "rustc --version" "rustc 1.80.0 (051478957 2024-07-21)"
-assert_cmd_output "rustfmt --version" "rustfmt 1.7.0-stable (05147895 2024-07-21)"
+assert_cmd_output "rustfmt --version" "rustfmt 1.7.0-stable (0514789* 2024-07-21)"
 assert_cmd_output "rustdoc --version" "rustdoc 1.80.0 (051478957 2024-07-21)"
 
 #### Toolchains ####

--- a/examples/bazel_env_test.sh
+++ b/examples/bazel_env_test.sh
@@ -88,12 +88,17 @@ Tools available in PATH:
   * pnpm:        @pnpm
   * python:      \$(PYTHON3)
   * python_tool: :python_tool
+  * cargo:       \$(CARGO)
+  * rustfmt:     \$(RUSTFMT)
+  * rustc:       \$(RUSTC)
+  * rustdoc:     \$(RUSTDOC)
 
 Toolchains available at stable relative paths:
   * cc_toolchain: bazel-out/bazel_env-opt/bin/bazel_env/toolchains/cc_toolchain
   * jdk:          bazel-out/bazel_env-opt/bin/bazel_env/toolchains/jdk
   * python:       bazel-out/bazel_env-opt/bin/bazel_env/toolchains/python
   * nodejs:       bazel-out/bazel_env-opt/bin/bazel_env/toolchains/nodejs
+  * rust:         bazel-out/bazel_env-opt/bin/bazel_env/toolchains/rust
 "
 }
 


### PR DESCRIPTION
Closes https://github.com/buildbuddy-io/bazel_env.bzl/issues/23

- Adds `cargo` and `rustfmt` to the example
- Small change to `bazel_env.bzl` in order to support the generated path for `cargo`

During my testing, I was finding that the [`raw_path`](https://github.com/buildbuddy-io/bazel_env.bzl/blob/920467407c064edb6180721c21a8a256e783cefb/bazel_env.bzl#L140) for `cargo` was of the following format:

```
bazel-out/darwin_arm64-opt/bin/external/rust_macos_aarch64_linux_tuple__aarch64-apple-darwin__stable_tools/rust_toolchain/bin/cargo
```

Which would result in paths that don't exist:

```
/Users/steven/dev/trimmed/bazel-out/bazel_env-opt-ST-6691f78f59fa/bin/bazel_env/bin/cargo: line 43: /Users/steven/dev/trimmed/bazel-out/bazel_env-opt-ST-6691f78f59fa/bin/bazel_env/bin/cargo.runfiles/_main/bazel-out/darwin_arm64-opt/bin/external/rust_macos_aarch64_linux_tuple__aarch64-apple-darwin__stable_tools/rust_toolchain/bin/cargo: No such file or directory
```

So the change trims strings that starts with `bazel-out/`, which allows `cargo` to resolve correctly.

With both `cargo` and `rustc` the user will be able to run commands like `cargo check` etc.