### PR TITLE
Fix BCR presubmit

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -8,6 +8,8 @@ bcr_test_module:
       name: "Run test module"
       platform: ${{ platform }}
       bazel: ${{ bazel }}
+      environment:
+        JAVA_TOOL_OPTIONS: ""
       build_targets:
         - "//..."
       test_targets:


### PR DESCRIPTION
`JAVA_TOOL_OPTIONS` interferes with `java` output in tests.