### PR TITLE
Add support for bazel-contrib/toolchains_llvm

### DIFF
--- a/bazel_env.bzl
+++ b/bazel_env.bzl
@@ -217,7 +217,7 @@ def _toolchain_impl(ctx):
             target.label,
             "for '{}' has no files{}".format(toolchain_name, suffix),
         )
-    if len(repos) > 1:
+    if len(repos) > 1 and "toolchains_llvm" not in repos.keys()[0]:
         fail(
             "toolchain target",
             target.label,


### PR DESCRIPTION
When using [`bazel-contrib/toolchains_llvm`](https://github.com/bazel-contrib/toolchains_llvm) and specifying:

```
toolchains = {
    "cc_toolchain": "@bazel_tools//tools/cpp:current_cc_toolchain",
},
```

You end up with the following error:

```
Error in fail: toolchain target @bazel_tools//tools/cpp:current_cc_toolchain for 'cc_toolchain' has files from different repositories: external/toolchains_llvm~~llvm~llvm_toolchain_llvm, external/toolchains_llvm~~llvm~llvm_toolchain
```

However the second one actually just points back to the first:

```
❯ ls -la /private/var/tmp/_bazel_steven/d71d77490eeb3a6c5a6efc45dc1ed897/external/toolchains_llvm\~\~llvm\~llvm_toolchain/bin
total 16
drwxr-xr-x@ 14 steven  wheel   448 Aug 31 13:21 .
drwxr-xr-x@  7 steven  wheel   224 Aug 31 13:21 ..
-rwxr-xr-x@  1 steven  wheel  6516 Aug 31 13:21 cc_wrapper.sh
lrwxr-xr-x@  1 steven  wheel   128 Aug 31 13:21 clang-cpp -> /private/var/tmp/_bazel_steven/d71d77490eeb3a6c5a6efc45dc1ed897/external/toolchains_llvm~~llvm~llvm_toolchain_llvm/bin/clang-cpp
lrwxr-xr-x@  1 steven  wheel   125 Aug 31 13:21 ld.lld -> /private/var/tmp/_bazel_steven/d71d77490eeb3a6c5a6efc45dc1ed897/external/toolchains_llvm~~llvm~llvm_toolchain_llvm/bin/ld.lld
lrwxr-xr-x@  1 steven  wheel   138 Aug 31 13:21 libtool -> /private/var/tmp/_bazel_steven/d71d77490eeb3a6c5a6efc45dc1ed897/external/toolchains_llvm~~llvm~llvm_toolchain_llvm/bin/llvm-libtool-darwin
<trimmed>
```

My current implementation here is just to add a special case for `toolchains_llvm`, however I understand that's probably not ideal. I'm open to better ideas.

Then there is the question of testing. I can add `toolchains_llvm` to `examples/` but we'll have to download a large pre-built llvm package as part of CI.