### PR TITLE
Add `print-path` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The [example](examples/) includes some commonly used tools and toolchains.
 
 ## Setup
 
-### Setup per project
+### Once per project
 
 1. Add a dependency on `bazel_env.bzl` to your `MODULE.bazel` file:
 
@@ -41,7 +41,7 @@ bazel_env(
 )
 ```
 
-3. Run the `bazel_env` target and follow the instructions to install `direnv` and set up the `.envrc` file:
+3. Run the `bazel_env` target and follow the instructions to install `direnv` and set up the `.envrc` file, which should be committed to version control:
 
 ```
 $ bazel run //:bazel_env
@@ -66,7 +66,7 @@ fi
 Multiple `bazel_env` targets can be added per project.
 Note that each target will eagerly fetch and build all tools and toolchains when built, so consider splitting them up into workflow-specific targets if necessary.
 
-### Setup for individual developers
+### Once per user
 
 1. Run the `bazel_env` target and follow the instructions to install `direnv` and allowlist the `.envrc` file:
 
@@ -106,6 +106,15 @@ Tools available in PATH:
 
 Toolchains available at stable relative paths:
   * jdk: bazel-out/bazel_env-opt/bin/bazel_env/toolchains/jdk
+```
+
+### Without `direnv` (e.g., in CI)
+
+Run the `print-path` subcommand of the `bazel_env` target and manually add its output to your `PATH`.
+For GitHub Actions, this can be done as follows:
+
+```
+$ bazel run //:bazel_env print-path >> $GITHUB_PATH
 ```
 
 ## Usage

--- a/examples/bazel_env_test.sh
+++ b/examples/bazel_env_test.sh
@@ -52,6 +52,22 @@ function assert_contains() {
 
 #### Status script ####
 
+# Verify the print-path subcommand works even without direnv.
+print_path_out=$(PATH="/bin:/usr/bin" \
+BUILD_WORKSPACE_DIRECTORY="$build_workspace_directory" \
+  ./bazel_env.sh print-path) || {
+    echo "print-path failed with output:"
+    echo "$print_path_out"
+    exit 1
+  }
+if [[ "$print_path_out" != "$build_workspace_directory/bazel-out/bazel_env-opt/bin/bazel_env/bin" ]]; then
+  echo "print-path output did not match the expected path:"
+  echo "  $print_path_out"
+  echo "Expected:"
+  echo "  $build_workspace_directory/bazel-out/bazel_env-opt/bin/bazel_env/bin"
+  exit 1
+fi
+
 # Place a fake direnv tool on the PATH.
 tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'tmpdir')
 trap 'rm -rf "$tmpdir"' EXIT

--- a/status.sh.tpl
+++ b/status.sh.tpl
@@ -2,13 +2,13 @@
 
 set -euo pipefail
 
-function print_usage() {
+function fail_with_usage() {
   echo "Usage: bazel run {{label}} [status|print-path]" >&2
   exit 1
 }
 
 if [[ $# -gt 1 ]]; then
-  print_usage
+  fail_with_usage
 fi
 
 if [[ $# -eq 1 ]]; then
@@ -22,7 +22,7 @@ if [[ "$subcommand" == "print-path" ]]; then
   exit 0
 fi
 if [[ "$subcommand" != "status" ]]; then
-  print_usage
+  fail_with_usage
 fi
 
 cd "$BUILD_WORKSPACE_DIRECTORY"

--- a/status.sh.tpl
+++ b/status.sh.tpl
@@ -2,6 +2,29 @@
 
 set -euo pipefail
 
+function print_usage() {
+  echo "Usage: bazel run {{label}} [status|print-path]" >&2
+  exit 1
+}
+
+if [[ $# -gt 1 ]]; then
+  print_usage
+fi
+
+if [[ $# -eq 1 ]]; then
+  subcommand="$1"
+else
+  subcommand="status"
+fi
+
+if [[ "$subcommand" == "print-path" ]]; then
+  echo "$BUILD_WORKSPACE_DIRECTORY/{{bin_dir}}"
+  exit 0
+fi
+if [[ "$subcommand" != "status" ]]; then
+  print_usage
+fi
+
 cd "$BUILD_WORKSPACE_DIRECTORY"
 
 cat << 'EOF'
@@ -26,7 +49,7 @@ else
 
 1. Enable direnv's shell hook as described in https://direnv.net/docs/hook.html.
 
-2. Add the following snippet to a .envrc file next to your MODULE.bazel file:
+2. Ensure that the following snippet is contained in a .envrc file next to your MODULE.bazel file:
 
 watch_file {{bin_dir}}
 PATH_add {{bin_dir}}


### PR DESCRIPTION
Prints the path to add to `PATH` in situations where using `direnv` isn't convenient to use, such as in CI.

Also tweak the docs to clarify which setup steps are relevant for whom.

Fixes #30 