### PR TITLE
Add support for builds with multiple exec platforms

### DIFF
--- a/bazel_env.bzl
+++ b/bazel_env.bzl
@@ -92,7 +92,16 @@ def _expand_make_variables(expression, vars):
 
 _COMPILATION_MODE_SETTING = "//command_line_option:compilation_mode"
 _CPU_SETTING = "//command_line_option:cpu"
+_EXTRA_EXECUTION_PLATFORMS_SETTING = "//command_line_option:extra_execution_platforms"
 _HOST_CPU_SETTING = "//command_line_option:host_cpu"
+_HOST_PLATFORM_SETTING = "//command_line_option:host_platform"
+_ALL_SETTINGS = [
+    _COMPILATION_MODE_SETTING,
+    _CPU_SETTING,
+    _EXTRA_EXECUTION_PLATFORMS_SETTING,
+    _HOST_CPU_SETTING,
+    _HOST_PLATFORM_SETTING,
+]
 
 def _flip_output_dir_impl(settings, _attr):
     # type: (dict[string, string | list[string]], attr) -> dict[string, string]
@@ -100,8 +109,14 @@ def _flip_output_dir_impl(settings, _attr):
         # Force "opt" mode for tools as they aren't rebuilt frequently and should be fast.
         # Force the output directory mnemonic to be the fixed string "bazel_env-opt" on all
         # platforms by using a fake CPU.
+        # Also ensure that the host platform has the highest precedence among the registered
+        # execution platforms so that toolchain resolution picks one that runs on the host.
+        # Note: We keep the target platform as is so that users can use toolchains with
+        # target constraints that are not the host platform, e.g., to have a C++ compiler compile
+        # for WASM if that's what the project usually does by setting `--platforms`.
         return settings | {
             _COMPILATION_MODE_SETTING: "opt",
+            _EXTRA_EXECUTION_PLATFORMS_SETTING: [settings[_HOST_PLATFORM_SETTING]],
             _CPU_SETTING: "bazel_env",
         }
     else:
@@ -115,16 +130,8 @@ def _flip_output_dir_impl(settings, _attr):
 
 _flip_output_dir = transition(
     implementation = _flip_output_dir_impl,
-    inputs = [
-        _COMPILATION_MODE_SETTING,
-        _CPU_SETTING,
-        _HOST_CPU_SETTING,
-    ],
-    outputs = [
-        _COMPILATION_MODE_SETTING,
-        _CPU_SETTING,
-        _HOST_CPU_SETTING,
-    ],
+    inputs = _ALL_SETTINGS,
+    outputs = _ALL_SETTINGS,
 )
 
 _ToolInfo = provider(fields = ["name", "raw_tool"])

--- a/bazel_env.bzl
+++ b/bazel_env.bzl
@@ -109,14 +109,11 @@ def _flip_output_dir_impl(settings, _attr):
         # Force "opt" mode for tools as they aren't rebuilt frequently and should be fast.
         # Force the output directory mnemonic to be the fixed string "bazel_env-opt" on all
         # platforms by using a fake CPU.
-        # Also ensure that the host platform has the highest precedence among the registered
-        # execution platforms so that toolchain resolution picks one that runs on the host.
-        # Note: We keep the target platform as is so that users can use toolchains with
-        # target constraints that are not the host platform, e.g., to have a C++ compiler compile
-        # for WASM if that's what the project usually does by setting `--platforms`.
+        # Important: don't set any settings other than --compilation_mode and --cpu as they
+        # would result in an ST hash appended to the output directory name, which must stay
+        # "bazel_env-opt". This is verified by tests.
         return settings | {
             _COMPILATION_MODE_SETTING: "opt",
-            _EXTRA_EXECUTION_PLATFORMS_SETTING: [settings[_HOST_PLATFORM_SETTING]],
             _CPU_SETTING: "bazel_env",
         }
     else:
@@ -124,8 +121,14 @@ def _flip_output_dir_impl(settings, _attr):
         # they usually shouldn't care about the value of --cpu and "bazel_env" is very unlikely
         # to have a platform mapping, but it's less confusing and potentially better for caching
         # if tool artifacts are under meaningful output directories.
+        # Also ensure that the host platform has the highest precedence among the registered
+        # execution platforms so that toolchain resolution picks one that runs on the host.
+        # Note: We keep the target platform as is so that users can use toolchains with
+        # target constraints that are not the host platform, e.g., to have a C++ compiler compile
+        # for WASM if that's what the project usually does by setting `--platforms`.
         return settings | {
             _CPU_SETTING: settings[_HOST_CPU_SETTING],
+            _EXTRA_EXECUTION_PLATFORMS_SETTING: [settings[_HOST_PLATFORM_SETTING]],
         }
 
 _flip_output_dir = transition(

--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -7,4 +7,6 @@ common --incompatible_disallow_empty_glob
 common --incompatible_strict_action_env
 common --nolegacy_external_runfiles
 common --nobuild_runfile_links
-common --noincompatible_enable_cc_toolchain_resolution
+# TODO: Uncomment this when it no longer crashes Bazel
+# https://github.com/bazelbuild/bazel/pull/25999
+# common --extra_execution_platforms=//:exotic_platform

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -48,11 +48,13 @@ py_binary(
     name = "python_tool",
     srcs = ["python_tool.py"],
     deps = [":python_tool_lib"],
+    tags = ["manual"],
 )
 
 py_library(
     name = "python_tool_lib",
     srcs = ["python_tool_lib.py"],
+    tags = ["manual"],
 )
 
 # Lines below are not part of the example, they are used to test the example.
@@ -81,4 +83,11 @@ sh_test(
 
 bazel_env(
     name = "empty_env",
+)
+
+platform(
+    name = "exotic_platform",
+    constraint_values = [
+        "@platforms//os:wasi",
+    ],
 )

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,7 +1,11 @@
+load("@bazel_env.bzl", "bazel_env")
 load("@buildozer//:buildozer.bzl", "BUILDOZER_LABEL")
 load("@multitool//:tools.bzl", MULTITOOL_TOOLS = "TOOLS")
 load("@rules_python//python:py_binary.bzl", "py_binary")
-load("@bazel_env.bzl", "bazel_env")
+
+# Test-only workaround for https://github.com/buildbuddy-io/bazel_env.bzl/pull/35#issuecomment-2853979830.
+# Ignore this line for the purpose of the example.
+load("@rules_shell//shell/private:sh_test.bzl", "sh_test")
 load(":test_helpers.bzl", "REPO_NAME_SEPARATOR")
 
 # `bazel run //:bazel_env` prints a summary and setup steps.
@@ -47,8 +51,8 @@ alias(
 py_binary(
     name = "python_tool",
     srcs = ["python_tool.py"],
-    deps = [":python_tool_lib"],
     tags = ["manual"],
+    deps = [":python_tool_lib"],
 )
 
 py_library(

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -29,6 +29,10 @@ single_version_override(
     version = "7.0.2",
 )
 
+register_execution_platforms(
+    "//:exotic_platform",
+)
+
 # Don't update the versions below, they are only used to verify the hermeticity of bazel_env.
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -18,7 +18,9 @@ bazel_dep(name = "rules_multitool", version = "1.3.0")
 bazel_dep(name = "rules_nodejs", version = "6.1.1")
 bazel_dep(name = "rules_python", version = "0.32.2")
 bazel_dep(name = "rules_rust", version = "0.49.3")
+bazel_dep(name = "rules_shell", version = "0.4.0")
 bazel_dep(name = "platforms", version = "0.0.10")
+
 # Required for compatibillity with Bazel@HEAD.
 single_version_override(
     module_name = "buildozer",


### PR DESCRIPTION
Also drop testing for `--noincompatible_enable_cc_toolchain_resolution`, which should be very uncommon by now, as it interferes with testing the common multi exec platform case.