### PR TITLE
Add rules_multitool to example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         bazel: [7.x, 8.x, last_green]
-        os: [ubuntu-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     env:
       BAZELISK_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ For GitHub Actions, this can be done as follows:
 $ bazel run //:bazel_env print-path >> $GITHUB_PATH
 ```
 
+### Fetching external tools
+
+[`rules_multitool`](https://github.com/theoremlp/rules_multitool) makes it easy to fetch tool binaries that match the host machine's architecture and OS and conveniently integrates with your `bazel_env` targets.
+If you define a multitool hub called `multitool`, just `load` the `TOOLS` dict from `@multitool//:tools.bzl` and append it to the `tools` attribute of your `bazel_env` target via `|`.
+The [example](examples/) demonstrates a use of `rules_multitool` to fetch tools such as `docker-compose` and `terraform`.
+
 ## Usage
 
 Build the `bazel_env` target to keep the tools and toolchains up-to-date with the Bazel build.

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@buildozer//:buildozer.bzl", "BUILDOZER_LABEL")
+load("@multitool//:tools.bzl", MULTITOOL_TOOLS = "TOOLS")
 load("@rules_python//python:py_binary.bzl", "py_binary")
 load("@bazel_env.bzl", "bazel_env")
 load(":test_helpers.bzl", "REPO_NAME_SEPARATOR")
@@ -31,7 +32,7 @@ bazel_env(
         "rustfmt": "$(RUSTFMT)",
         "rustc": "$(RUSTC)",
         "rustdoc": "$(RUSTDOC)",
-    },
+    } | MULTITOOL_TOOLS,
 )
 
 alias(

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -10,15 +10,20 @@ local_path_override(
 )
 
 bazel_dep(name = "aspect_rules_js", version = "2.0.0-rc4")
-bazel_dep(name = "buildifier_prebuilt", version = "6.4.0")
+bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")
 bazel_dep(name = "buildozer", version = "7.1.2")
 bazel_dep(name = "rules_go", version = "0.47.1")
 bazel_dep(name = "rules_java", version = "7.6.4")
+bazel_dep(name = "rules_multitool", version = "1.3.0")
 bazel_dep(name = "rules_nodejs", version = "6.1.1")
 bazel_dep(name = "rules_python", version = "0.32.2")
 bazel_dep(name = "rules_rust", version = "0.49.3")
 bazel_dep(name = "platforms", version = "0.0.10")
 # Required for compatibillity with Bazel@HEAD.
+single_version_override(
+    module_name = "buildozer",
+    version = "7.1.2",
+)
 single_version_override(
     module_name = "rules_proto",
     version = "7.0.2",
@@ -81,3 +86,7 @@ http_file(
     integrity = "sha256-6+zYQLpH779mgihoF4zHIaFRBgk396xAbj0xvQFb3pQ=",
     urls = ["https://github.com/jqlang/jq/releases/download/jq-1.5/jq-win64.exe"],
 )
+
+multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
+multitool.hub(lockfile = "//:tools.lock.json")
+use_repo(multitool, "multitool")

--- a/examples/bazel_env_test.sh
+++ b/examples/bazel_env_test.sh
@@ -108,11 +108,11 @@ Tools available in PATH:
   * rustfmt:        \$(RUSTFMT)
   * rustc:          \$(RUSTC)
   * rustdoc:        \$(RUSTDOC)
-  * buf:            @@rules_multitool++multitool+multitool//tools/buf:buf
-  * docker-compose: @@rules_multitool++multitool+multitool//tools/docker-compose:docker-compose
-  * ibazel:         @@rules_multitool++multitool+multitool//tools/ibazel:ibazel
-  * multitool:      @@rules_multitool++multitool+multitool//tools/multitool:multitool
-  * terraform:      @@rules_multitool++multitool+multitool//tools/terraform:terraform
+  * buf:            @@rules_multitool${sep}${sep}multitool${sep}multitool//tools/buf:buf
+  * docker-compose: @@rules_multitool${sep}${sep}multitool${sep}multitool//tools/docker-compose:docker-compose
+  * ibazel:         @@rules_multitool${sep}${sep}multitool${sep}multitool//tools/ibazel:ibazel
+  * multitool:      @@rules_multitool${sep}${sep}multitool${sep}multitool//tools/multitool:multitool
+  * terraform:      @@rules_multitool${sep}${sep}multitool${sep}multitool//tools/terraform:terraform
 
 Toolchains available at stable relative paths:
   * cc_toolchain: bazel-out/bazel_env-opt/bin/bazel_env/toolchains/cc_toolchain

--- a/examples/bazel_env_test.sh
+++ b/examples/bazel_env_test.sh
@@ -93,21 +93,26 @@ function expected_output {
 ✅ direnv added bazel-out/bazel_env-opt/bin/bazel_env/bin to PATH
 
 Tools available in PATH:
-  * bazel-cc:    \$(CC)
-  * buildifier:  @buildifier_prebuilt//:buildifier
-  * buildozer:   @@buildozer${sep}${sep}buildozer_binary${sep}buildozer_binary//:buildozer.exe
-  * go:          @rules_go//go
-  * jar:         \$(JAVABASE)/bin/jar
-  * java:        \$(JAVA)
-  * jq:          :jq
-  * node:        \$(NODE_PATH)
-  * pnpm:        @pnpm
-  * python:      \$(PYTHON3)
-  * python_tool: :python_tool
-  * cargo:       \$(CARGO)
-  * rustfmt:     \$(RUSTFMT)
-  * rustc:       \$(RUSTC)
-  * rustdoc:     \$(RUSTDOC)
+  * bazel-cc:       \$(CC)
+  * buildifier:     @buildifier_prebuilt//:buildifier
+  * buildozer:      @@buildozer${sep}${sep}buildozer_binary${sep}buildozer_binary//:buildozer.exe
+  * go:             @rules_go//go
+  * jar:            \$(JAVABASE)/bin/jar
+  * java:           \$(JAVA)
+  * jq:             :jq
+  * node:           \$(NODE_PATH)
+  * pnpm:           @pnpm
+  * python:         \$(PYTHON3)
+  * python_tool:    :python_tool
+  * cargo:          \$(CARGO)
+  * rustfmt:        \$(RUSTFMT)
+  * rustc:          \$(RUSTC)
+  * rustdoc:        \$(RUSTDOC)
+  * buf:            @@rules_multitool++multitool+multitool//tools/buf:buf
+  * docker-compose: @@rules_multitool++multitool+multitool//tools/docker-compose:docker-compose
+  * ibazel:         @@rules_multitool++multitool+multitool//tools/ibazel:ibazel
+  * multitool:      @@rules_multitool++multitool+multitool//tools/multitool:multitool
+  * terraform:      @@rules_multitool++multitool+multitool//tools/terraform:terraform
 
 Toolchains available at stable relative paths:
   * cc_toolchain: bazel-out/bazel_env-opt/bin/bazel_env/toolchains/cc_toolchain
@@ -123,7 +128,7 @@ diff <(expected_output "$BAZEL_REPO_NAME_SEPARATOR") <(echo "$status_out") || ex
 #### Tools ####
 
 assert_cmd_output "bazel-cc --version" "@(*gcc*|*clang*)"
-assert_cmd_output "buildifier --version" "buildifier version: 6.4.0 "
+assert_cmd_output "buildifier --version" "buildifier version: 7.3.1 "
 assert_cmd_output "buildozer --version" "buildozer version: 7.1.2 "
 case "$(arch)" in
   i386|x86_64) goarch="amd64";;
@@ -142,6 +147,11 @@ assert_cmd_output "cargo --version" "cargo 1.80.0 (376290515 2024-07-16)"
 assert_cmd_output "rustc --version" "rustc 1.80.0 (051478957 2024-07-21)"
 assert_cmd_output "rustfmt --version" "rustfmt 1.7.0-stable (0514789* 2024-07-21)"
 assert_cmd_output "rustdoc --version" "rustdoc 1.80.0 (051478957 2024-07-21)"
+assert_cmd_output "buf --version" "1.39.0"
+assert_cmd_output "docker-compose --version" "Docker Compose version v2.29.2"
+assert_cmd_output "ibazel" "iBazel - Version v0.25.3"
+assert_cmd_output "multitool --help" "Usage: multitool [OPTIONS] <COMMAND>"
+assert_cmd_output "terraform --version" "Terraform v1.9.3"
 
 #### Toolchains ####
 

--- a/examples/tools.lock.json
+++ b/examples/tools.lock.json
@@ -22,13 +22,6 @@
                 "sha256": "7163faf9da829afa633194ffa11e4a4ef8d7b8359cefbc13f71a58cc3b860d9e",
                 "os": "macos",
                 "cpu": "arm64"
-            },
-            {
-                "kind": "file",
-                "url": "https://github.com/bufbuild/buf/releases/download/v1.39.0/buf-Darwin-x86_64",
-                "sha256": "b44da381dfc9980aed822476d12645f981761ea8ac7f135772d9f02246c8ac31",
-                "os": "macos",
-                "cpu": "x86_64"
             }
         ]
     },

--- a/examples/tools.lock.json
+++ b/examples/tools.lock.json
@@ -1,0 +1,141 @@
+{
+    "$schema": "https://raw.githubusercontent.com/theoremlp/rules_multitool/main/lockfile.schema.json",
+    "buf": {
+        "binaries": [
+            {
+                "kind": "file",
+                "url": "https://github.com/bufbuild/buf/releases/download/v1.39.0/buf-Linux-aarch64",
+                "sha256": "e22b59798211d0904553f891861208222d88e2cf0257a370440f7817a21dffd3",
+                "os": "linux",
+                "cpu": "arm64"
+            },
+            {
+                "kind": "file",
+                "url": "https://github.com/bufbuild/buf/releases/download/v1.39.0/buf-Linux-x86_64",
+                "sha256": "657eaafbe1cbeafecfda15386004bd3253fc91162e68cd52185937e3ff4d7afe",
+                "os": "linux",
+                "cpu": "x86_64"
+            },
+            {
+                "kind": "file",
+                "url": "https://github.com/bufbuild/buf/releases/download/v1.39.0/buf-Darwin-arm64",
+                "sha256": "7163faf9da829afa633194ffa11e4a4ef8d7b8359cefbc13f71a58cc3b860d9e",
+                "os": "macos",
+                "cpu": "arm64"
+            },
+            {
+                "kind": "file",
+                "url": "https://github.com/bufbuild/buf/releases/download/v1.39.0/buf-Darwin-x86_64",
+                "sha256": "b44da381dfc9980aed822476d12645f981761ea8ac7f135772d9f02246c8ac31",
+                "os": "macos",
+                "cpu": "x86_64"
+            }
+        ]
+    },
+    "docker-compose": {
+        "binaries": [
+            {
+                "kind": "file",
+                "url": "https://github.com/docker/compose/releases/download/v2.29.2/docker-compose-linux-aarch64",
+                "sha256": "1caa6c39b9df88dbd8522403d78b786a4151fa4e881c866725f75b5d99500a9d",
+                "os": "linux",
+                "cpu": "arm64"
+            },
+            {
+                "kind": "file",
+                "url": "https://github.com/docker/compose/releases/download/v2.29.2/docker-compose-linux-x86_64",
+                "sha256": "d037bd4937bf18fba67cff4366e084ee125a3e15c25657ee1aeceff8db3672b4",
+                "os": "linux",
+                "cpu": "x86_64"
+            },
+            {
+                "kind": "file",
+                "url": "https://github.com/docker/compose/releases/download/v2.29.2/docker-compose-darwin-aarch64",
+                "sha256": "518c4c4aacaa3f5175356e2c47ffcd278e7dd4228c97d83d1f396a9819d4f030",
+                "os": "macos",
+                "cpu": "arm64"
+            }
+        ]
+    },
+    "ibazel": {
+        "binaries": [
+            {
+                "kind": "file",
+                "url": "https://github.com/bazelbuild/bazel-watcher/releases/download/v0.25.3/ibazel_linux_arm64",
+                "sha256": "3fa76bef2a1eac55975a0e6949c133d0a9898eb1e5425ce4f7df0289859f56c5",
+                "os": "linux",
+                "cpu": "arm64"
+            },
+            {
+                "kind": "file",
+                "url": "https://github.com/bazelbuild/bazel-watcher/releases/download/v0.25.3/ibazel_linux_amd64",
+                "sha256": "d8e1ea02777670a095719ed3800e9bbf814269b05edf901992c1e7c5eca0e3b6",
+                "os": "linux",
+                "cpu": "x86_64"
+            },
+            {
+                "kind": "file",
+                "url": "https://github.com/bazelbuild/bazel-watcher/releases/download/v0.25.3/ibazel_darwin_arm64",
+                "sha256": "c2da75cbab7a4b2b97ba534653bb12e4dd731157bb1c9d660f79df3b330a7239",
+                "os": "macos",
+                "cpu": "arm64"
+            }
+        ]
+    },
+    "multitool": {
+        "binaries": [
+            {
+                "kind": "archive",
+                "url": "https://github.com/theoremlp/multitool/releases/download/v0.8.0/multitool-aarch64-unknown-linux-gnu.tar.xz",
+                "file": "multitool-aarch64-unknown-linux-gnu/multitool",
+                "sha256": "e249591e31fd3f7f27782d3b3da1ce077f9432fdfc7e163bac2b7cf43c3f87a0",
+                "os": "linux",
+                "cpu": "arm64"
+            },
+            {
+                "kind": "archive",
+                "url": "https://github.com/theoremlp/multitool/releases/download/v0.8.0/multitool-x86_64-unknown-linux-gnu.tar.xz",
+                "file": "multitool-x86_64-unknown-linux-gnu/multitool",
+                "sha256": "fc7e5e78f8efa6173cb82659f48ef0acd6ae6f0b906781ab9d4b058f774f657c",
+                "os": "linux",
+                "cpu": "x86_64"
+            },
+            {
+                "kind": "archive",
+                "url": "https://github.com/theoremlp/multitool/releases/download/v0.8.0/multitool-aarch64-apple-darwin.tar.xz",
+                "file": "multitool-aarch64-apple-darwin/multitool",
+                "sha256": "3187c94895358820c656c6a1736d442b3a568a5b1dd17c4c35f3903a07b709a2",
+                "os": "macos",
+                "cpu": "arm64"
+            }
+        ]
+    },
+    "terraform": {
+        "binaries": [
+            {
+                "kind": "archive",
+                "url": "https://releases.hashicorp.com/terraform/1.9.3/terraform_1.9.3_linux_arm64.zip",
+                "file": "terraform",
+                "sha256": "193ce269aafd5c44f359cd73a75c5cc7aaab924eb5c3601784c1873575828ec7",
+                "os": "linux",
+                "cpu": "arm64"
+            },
+            {
+                "kind": "archive",
+                "url": "https://releases.hashicorp.com/terraform/1.9.3/terraform_1.9.3_linux_amd64.zip",
+                "file": "terraform",
+                "sha256": "e52520cf6d677155e69a8fcfe64054891f4d991802b0d36d4c8b670d60a7e899",
+                "os": "linux",
+                "cpu": "x86_64"
+            },
+            {
+                "kind": "archive",
+                "url": "https://releases.hashicorp.com/terraform/1.9.3/terraform_1.9.3_darwin_arm64.zip",
+                "file": "terraform",
+                "sha256": "168cfeb339dbbfea6be651573ec168e6ca08bab79a4fc0474681eee1e9a95de9",
+                "os": "macos",
+                "cpu": "arm64"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Drop testing on Intel Macs as some external tools aren't available for them anymore.

Fixes #32 