### PR TITLE
Instruct users to clear their shell's commands cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ The [example](examples/) demonstrates a use of `rules_multitool` to fetch tools 
 Build the `bazel_env` target to keep the tools and toolchains up-to-date with the Bazel build.
 The target can also be executed with `bazel run` to print the list of tools and toolchains as well as clean up removed tools.
 
+> [!IMPORTANT]
+> Shells such as `bash` and `zsh` will not automatically pick up changes to directories in `PATH`.
+> You may need to run `hash -r` or `rehash` to clear the shell's command cache.
+> `bazel run //:bazel_env` will print the command to run.
+
 ## Documentation
 
 See the [generated documentation](docs-gen/bazel_env.md) for more information on the `bazel_env` rule.

--- a/examples/bazel_env_test.sh
+++ b/examples/bazel_env_test.sh
@@ -120,6 +120,8 @@ Toolchains available at stable relative paths:
   * python:       bazel-out/bazel_env-opt/bin/bazel_env/toolchains/python
   * nodejs:       bazel-out/bazel_env-opt/bin/bazel_env/toolchains/nodejs
   * rust:         bazel-out/bazel_env-opt/bin/bazel_env/toolchains/rust
+
+⚠️  Remember to run 'hash -r' in bash to update the locations of binaries on the PATH.
 "
 }
 

--- a/status.sh.tpl
+++ b/status.sh.tpl
@@ -96,8 +96,8 @@ fi
 
 set +e
 # $$ is bash's PID, $PPID is Bazel's PID.
-outer_shell_pid=$(ps -o ppid= $PPID)
-outer_shell_name=$(ps -cp "$outer_shell_pid" -o command="")
+outer_shell_pid=$(ps -o ppid= -p $PPID | tr -d ' ')
+outer_shell_name=$(ps -p "$outer_shell_pid" -o comm= | tr -d ' ')
 set -e
 if [[ "$outer_shell_name" == *zsh* ]]; then
   echo "⚠️  Remember to run 'rehash' in zsh to update the locations of binaries on the PATH."

--- a/status.sh.tpl
+++ b/status.sh.tpl
@@ -93,3 +93,14 @@ Toolchains available at stable relative paths:
 
 EOF
 fi
+
+set +e
+# $$ is bash's PID, $PPID is Bazel's PID.
+outer_shell_pid=$(ps -o ppid= $PPID)
+outer_shell_name=$(ps -cp "$outer_shell_pid" -o command="")
+set -e
+if [[ "$outer_shell_name" == *zsh* ]]; then
+  echo "⚠️  Remember to run 'rehash' in zsh to update the locations of binaries on the PATH."
+elif [[ "$outer_shell_name" == *bash* ]]; then
+  echo "⚠️  Remember to run 'hash -r' in bash to update the locations of binaries on the PATH."
+fi


### PR DESCRIPTION
Until we find an automated solution, telling the user to run `hash -r` or `rehash` when they need to do so is the best we can do.

Work towards #15