### PR TITLE
Add test coverage for `filegroup`s in `toolchains`

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -18,6 +18,7 @@ bazel_env(
         "python": "@rules_python//python:current_py_toolchain",
         "nodejs": "@nodejs_toolchains//:resolved_toolchain",
         "rust": "@rules_rust//rust/toolchain:current_rust_toolchain",
+        "rules_python_docs": "@rules_python_docs",
     },
     tools = {
         # Tool paths can reference the Make variables provided by toolchains.

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -94,6 +94,22 @@ http_file(
     urls = ["https://github.com/jqlang/jq/releases/download/jq-1.7/jq-win64.exe"],
 )
 
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_python_docs",
+    url = "https://github.com/bazel-contrib/rules_python/releases/download/1.4.1/rules_python-1.4.1.tar.gz",
+    integrity = "sha256-n587MAqSZOTHeZkxLOZjvl3umlbjYaH2/n7GDhvu+aM=",
+    strip_prefix = "rules_python-1.4.1/docs",
+    build_file_content = """
+filegroup(
+    name = "rules_python_docs",
+    srcs = glob(["**/*.md"]),
+    visibility = ["//visibility:public"],
+)
+""",
+)
+
 multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
 multitool.hub(lockfile = "//:tools.lock.json")
 use_repo(multitool, "multitool")

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -11,17 +11,17 @@ local_path_override(
 
 bazel_dep(name = "aspect_rules_js", version = "2.0.0-rc4")
 bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")
-bazel_dep(name = "buildozer", version = "7.1.2")
-bazel_dep(name = "rules_go", version = "0.47.1")
+bazel_dep(name = "buildozer")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_go")
 bazel_dep(name = "rules_java", version = "8.12.0")
 bazel_dep(name = "rules_multitool", version = "1.3.0")
 bazel_dep(name = "rules_nodejs", version = "6.1.1")
 bazel_dep(name = "rules_python", version = "1.3.0")
 bazel_dep(name = "rules_rust", version = "0.49.3")
-bazel_dep(name = "rules_shell", version = "0.4.0")
-bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_shell", version = "0.4.1")
 
-# Required for compatibillity with Bazel@HEAD.
+# Required for compatibility with Bazel@HEAD.
 single_version_override(
     module_name = "buildozer",
     version = "7.1.2",
@@ -32,6 +32,20 @@ single_version_override(
     version = "7.0.2",
 )
 
+# TODO: Replace with a bazel_dep after the next release of aspect_bazel_lib.
+git_override(
+    module_name = "aspect_bazel_lib",
+    commit = "930a0601df7c6c04d5b000e39251987e57d32d57",
+    remote = "https://github.com/bazel-contrib/bazel-lib",
+)
+
+# TODO: Remove after the next release of rules_go.
+git_override(
+    module_name = "rules_go",
+    commit = "ae5ce4950fbcc7f0a0cc4b4485891c41eada395e",
+    remote = "https://github.com/bazel-contrib/rules_go",
+)
+
 register_execution_platforms(
     "//:exotic_platform",
 )
@@ -39,7 +53,7 @@ register_execution_platforms(
 # Don't update the versions below, they are only used to verify the hermeticity of bazel_env.
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.20.14")
+go_sdk.download(version = "1.21.13")
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
 node.toolchain(
@@ -96,11 +110,9 @@ http_file(
 
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# An example of a filegroup to be made available under a fixed path with bazel_env.
 http_archive(
     name = "rules_python_docs",
-    url = "https://github.com/bazel-contrib/rules_python/releases/download/1.4.1/rules_python-1.4.1.tar.gz",
-    integrity = "sha256-n587MAqSZOTHeZkxLOZjvl3umlbjYaH2/n7GDhvu+aM=",
-    strip_prefix = "rules_python-1.4.1/docs",
     build_file_content = """
 filegroup(
     name = "rules_python_docs",
@@ -108,6 +120,9 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 """,
+    integrity = "sha256-n587MAqSZOTHeZkxLOZjvl3umlbjYaH2/n7GDhvu+aM=",
+    strip_prefix = "rules_python-1.4.1/docs",
+    url = "https://github.com/bazel-contrib/rules_python/releases/download/1.4.1/rules_python-1.4.1.tar.gz",
 )
 
 multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")

--- a/examples/bazel_env_test.sh
+++ b/examples/bazel_env_test.sh
@@ -115,11 +115,12 @@ Tools available in PATH:
   * terraform:      @@rules_multitool${sep}${sep}multitool${sep}multitool//tools/terraform:terraform
 
 Toolchains available at stable relative paths:
-  * cc_toolchain: bazel-out/bazel_env-opt/bin/bazel_env/toolchains/cc_toolchain
-  * jdk:          bazel-out/bazel_env-opt/bin/bazel_env/toolchains/jdk
-  * python:       bazel-out/bazel_env-opt/bin/bazel_env/toolchains/python
-  * nodejs:       bazel-out/bazel_env-opt/bin/bazel_env/toolchains/nodejs
-  * rust:         bazel-out/bazel_env-opt/bin/bazel_env/toolchains/rust
+  * cc_toolchain:      bazel-out/bazel_env-opt/bin/bazel_env/toolchains/cc_toolchain
+  * jdk:               bazel-out/bazel_env-opt/bin/bazel_env/toolchains/jdk
+  * python:            bazel-out/bazel_env-opt/bin/bazel_env/toolchains/python
+  * nodejs:            bazel-out/bazel_env-opt/bin/bazel_env/toolchains/nodejs
+  * rust:              bazel-out/bazel_env-opt/bin/bazel_env/toolchains/rust
+  * rules_python_docs: bazel-out/bazel_env-opt/bin/bazel_env/toolchains/rules_python_docs
 
 ⚠️  Remember to run 'hash -r' in bash to update the locations of binaries on the PATH.
 "
@@ -162,3 +163,4 @@ assert_cmd_output "$build_workspace_directory/bazel-out/bazel_env-opt/bin/bazel_
 assert_cmd_output "$build_workspace_directory/bazel-out/bazel_env-opt/bin/bazel_env/toolchains/python/bin/python3 --version" "Python 3.11.8"
 assert_cmd_output "$build_workspace_directory/bazel-out/bazel_env-opt/bin/bazel_env/toolchains/rust/bin/cargo --version" "cargo 1.80.0 (376290515 2024-07-16)"
 assert_cmd_output "$build_workspace_directory/bazel-out/bazel_env-opt/bin/bazel_env/toolchains/rust/bin/rustc --version" "rustc 1.80.0 (051478957 2024-07-21)"
+[[ -f "$build_workspace_directory/bazel-out/bazel_env-opt/bin/bazel_env/toolchains/rules_python_docs/extending.md" ]]

--- a/examples/bazel_env_test.sh
+++ b/examples/bazel_env_test.sh
@@ -137,7 +137,7 @@ case "$(arch)" in
   i386|x86_64) goarch="amd64";;
   *) goarch="$(arch)";;
 esac
-assert_cmd_output "go version" "go version go1.20.14 $(uname|tr '[:upper:]' '[:lower:]')/$goarch"
+assert_cmd_output "go version" "go version go1.21.13 $(uname|tr '[:upper:]' '[:lower:]')/$goarch"
 assert_cmd_output "jar --version" "jar 17.0.14"
 assert_cmd_output "java --version" "openjdk 17.0.14 2025-01-21 LTS"
 assert_cmd_output "jq --version" "jq-1.7"


### PR DESCRIPTION
The name suggests that only resolved toolchain targets are accepted, but we do in fact support anything that provides files.

Also pin some dependencies to recent versions that restore compatibility with Bazel@HEAD.