### PR TITLE
feat: Conditional output when tool can't be found based on what steps are missing

### DIFF
--- a/status.sh.tpl
+++ b/status.sh.tpl
@@ -44,21 +44,36 @@ fi
 if type {{unique_name_tool}} >/dev/null 2>/dev/null; then
     echo "✅ direnv added {{bin_dir}} to PATH"
 else
-    cat << 'EOF'
-❌ {{name}}'s bin directory is not in PATH. Please follow these steps:
+    echo "❌ {{name}}'s bin directory is not in PATH. Please follow these steps:"
 
-1. Enable direnv's shell hook as described in https://direnv.net/docs/hook.html.
+    step_num=1
+    
+    if [[ -z "${DIRENV_DIR:-}" ]]; then
+      echo ""
+      echo "$step_num. Enable direnv's shell hook as described in https://direnv.net/docs/hook.html."
+      step_num=$((step_num + 1))
+    fi
 
-2. Ensure that the following snippet is contained in a .envrc file next to your MODULE.bazel file:
+    if ! grep -qE '[[:<:]]bazel_env[[:>:]]' .envrc 2>/dev/null; then
+      echo ""
+      if [[ -f .envrc ]]; then
+        echo "$step_num. Add the following content to your existing .envrc file:"
+      else
+        echo "$step_num. Create a .envrc file next to your MODULE.bazel file with this content:"
+      fi
+      cat << 'EOF'
 
 watch_file {{bin_dir}}
 PATH_add {{bin_dir}}
 if [[ ! -d {{bin_dir}} ]]; then
   log_error "ERROR[bazel_env.bzl]: Run 'bazel run {{label}}' to regenerate {{bin_dir}}"
 fi
-
-3. Allowlist the file with 'direnv allow .envrc'.
 EOF
+      step_num=$((step_num + 1))
+    fi
+
+    echo ""
+    echo "$step_num. Run 'direnv allow' to allowlist your .envrc file."
     exit 1
 fi
 


### PR DESCRIPTION
Tested in `examples`.

- [ ] Hook set up
- [ ] .envrc file exists
- [ ] bazel_env configured in .envrc
- [ ] direnv allow .envrc
```
> bazel run :bazel_env
INFO: Analyzed target //:bazel_env (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //:bazel_env up-to-date:
  bazel-bin/bazel_env_all_tools
INFO: Elapsed time: 0.198s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/bazel_env.sh

====== bazel_env ======

✅ direnv is installed
❌ bazel_env's bin directory is not in PATH. Please follow these steps:

1. Enable direnv's shell hook as described in https://direnv.net/docs/hook.html.

2. Create a .envrc file next to your MODULE.bazel file with this content:

watch_file bazel-out/bazel_env-opt/bin/bazel_env/bin
PATH_add bazel-out/bazel_env-opt/bin/bazel_env/bin
if [[ ! -d bazel-out/bazel_env-opt/bin/bazel_env/bin ]]; then
  log_error "ERROR[bazel_env.bzl]: Run 'bazel run //:bazel_env' to regenerate bazel-out/bazel_env-opt/bin/bazel_env/bin"
fi

3. Run 'direnv allow' to allowlist your .envrc file.
```

- [x] Hook set up
- [ ] .envrc file exists
- [ ] bazel_env configured in .envrc
- [ ] direnv allow .envrc
```
> bazel run //:bazel_env
INFO: Analyzed target //:bazel_env (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //:bazel_env up-to-date:
  bazel-bin/bazel_env_all_tools
INFO: Elapsed time: 0.234s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/bazel_env.sh

====== bazel_env ======

✅ direnv is installed
❌ bazel_env's bin directory is not in PATH. Please follow these steps:

1. Create a .envrc file next to your MODULE.bazel file with this content:

watch_file bazel-out/bazel_env-opt/bin/bazel_env/bin
PATH_add bazel-out/bazel_env-opt/bin/bazel_env/bin
if [[ ! -d bazel-out/bazel_env-opt/bin/bazel_env/bin ]]; then
  log_error "ERROR[bazel_env.bzl]: Run 'bazel run //:bazel_env' to regenerate bazel-out/bazel_env-opt/bin/bazel_env/bin"
fi

2. Run 'direnv allow' to allowlist your .envrc file.
```

- [ ] Hook set up
- [x] .envrc file exists
- [ ] bazel_env configured in .envrc
- [ ] direnv allow .envrc
```
> bazel run //:bazel_env
INFO: Analyzed target //:bazel_env (1 packages loaded, 19 targets configured).
INFO: Found 1 target...
Target //:bazel_env up-to-date:
  bazel-bin/bazel_env_all_tools
INFO: Elapsed time: 0.236s, Critical Path: 0.01s
INFO: 1 process: 956 action cache hit, 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/bazel_env.sh

====== bazel_env ======

✅ direnv is installed
❌ bazel_env's bin directory is not in PATH. Please follow these steps:

1. Add the following content to your existing .envrc file:

watch_file bazel-out/bazel_env-opt/bin/bazel_env/bin
PATH_add bazel-out/bazel_env-opt/bin/bazel_env/bin
if [[ ! -d bazel-out/bazel_env-opt/bin/bazel_env/bin ]]; then
  log_error "ERROR[bazel_env.bzl]: Run 'bazel run //:bazel_env' to regenerate bazel-out/bazel_env-opt/bin/bazel_env/bin"
fi

2. Run 'direnv allow' to allowlist your .envrc file.
```

- [ ] Hook set up
- [x] .envrc file exists
- [x] bazel_env configured in .envrc
- [ ] direnv allow .envrc
```
> bazel run //:bazel_env
INFO: Analyzed target //:bazel_env (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //:bazel_env up-to-date:
  bazel-bin/bazel_env_all_tools
INFO: Elapsed time: 0.188s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/bazel_env.sh

====== bazel_env ======

✅ direnv is installed
❌ bazel_env's bin directory is not in PATH. Please follow these steps:

1. Enable direnv's shell hook as described in https://direnv.net/docs/hook.html.

2. Run 'direnv allow' to allowlist your .envrc file.
```

- [x] Hook set up
- [x] .envrc file exists
- [x] bazel_env configured in .envrc
- [ ] direnv allow .envrc
```
> bazel run //:bazel_env
INFO: Analyzed target //:bazel_env (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //:bazel_env up-to-date:
  bazel-bin/bazel_env_all_tools
INFO: Elapsed time: 0.198s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/bazel_env.sh

====== bazel_env ======

✅ direnv is installed
❌ bazel_env's bin directory is not in PATH. Please follow these steps:

1. Run 'direnv allow' to allowlist your .envrc file.
```

- [x] Hook set up
- [x] .envrc file exists
- [x] bazel_env configured in .envrc
- [x] direnv allow .envrc
```
> bazel run :bazel_env
INFO: Analyzed target //:bazel_env (1 packages loaded, 19 targets configured).
INFO: Found 1 target...
Target //:bazel_env up-to-date:
  bazel-bin/bazel_env_all_tools
INFO: Elapsed time: 0.456s, Critical Path: 0.01s
INFO: 1 process: 956 action cache hit, 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/bazel_env.sh

====== bazel_env ======

✅ direnv is installed
✅ direnv added bazel-out/bazel_env-opt/bin/bazel_env/bin to PATH

[...]
```