### PR TITLE
Fix examples repo build failure on macOS

### DIFF
--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -9,6 +9,7 @@ local_path_override(
     path = "..",
 )
 
+bazel_dep(name = "apple_support", version = "1.24.3")
 bazel_dep(name = "aspect_rules_js", version = "2.0.0-rc4")
 bazel_dep(name = "bazel_features", version = "1.33.0")
 bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")


### PR DESCRIPTION
It's not clear how the colon ends up in the linker name:

```
clang: error: invalid linker name in argument '-fuse-ld=ld64.lld:'
```