### PR TITLE
Set JS_BINARY__PATCH_NODE_FS=0 to allow js_binary to follow symlinks

### DIFF
--- a/launcher.sh.tpl
+++ b/launcher.sh.tpl
@@ -187,6 +187,8 @@ export JAVA_RUNFILES="${RUNFILES_DIR}"
 export PYTHON_RUNFILES="${RUNFILES_DIR}"
 # Let rules_js' js_binary work by not having it try to cd into BINDIR.
 export JS_BINARY__NO_CD_BINDIR=1
+# Let rules_js's js_binary work by allowing it to follow symlinks outside of sandbox.
+export JS_BINARY__PATCH_NODE_FS=0
 # Environment of the executable target.
 {{extra_env}}
 


### PR DESCRIPTION
## This PR allows aspect_rules_js js binaries exposed through bazel_env to behave identically to their non-Bazel counterparts

### Problem
We wanted to expose `pnpm` through `bazel_env`  (following this https://github.com/bazel-starters/js/blob/main/tools/BUILD#L43), but we quickly realised that this pnpm does not quite behave as a "normal" one (globally installed one, for example).

The main difference was in how `pnpm run <script>` behaved if the script had to load other modules. With global pnpm, everything worked as expected, but the Bazel one would often fail to find modules, even if they were there.
Another situation that we had is ESLint, whose config has imports. We imagine there are others as well.

After some research, we figured out that every `js_binary` sets `patch_node_fs = True` by default, which disallows it from following symlinks out of the execroot, runfiles and sandbox. This ensures correctness when running under Bazel, but breaks when running outside of it.
See https://github.com/aspect-build/rules_js/blob/main/js/private/js_binary.bzl#L194

We set it to false for all binaries that we use through `bazel_env`. This fixed `pnpm` and all the other tools as well.

### Solution
This PR sets `JS_BINARY__PATCH_NODE_FS=0` (equivalent to `patch_node_fs = False` in `js_binary`) which removes the default restriction for binaries to follow symlinks outside of sandbox, making the tools behave like their global counterparts.

### Verification
This is verified locally with pnpm and other `js_binary` tools we have in our monorepo.