### PR TITLE
Fix stale runfiles rebuild

### DIFF
--- a/examples/bazel_env_test.sh
+++ b/examples/bazel_env_test.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 
 build_workspace_directory="$(dirname "$(readlink -f MODULE.bazel)")"
 
+# This test runs against a local workspace, so clear any prior watch state.
+rm -f "$build_workspace_directory/bazel_env.lock"
+
 # Run a command with a minimal PATH including the bazel_env and assert its
 # output, possibly with wildcards.
 function assert_cmd_output() {
@@ -48,6 +51,19 @@ function assert_contains() {
     echo "$content"
     exit 1
   }
+}
+
+function run_cmd() {
+  local -r cmd="$1"
+  local -r extra_path="${2:-}"
+
+  env \
+    -u TEST_SRCDIR \
+    -u RUNFILES_DIR \
+    -u RUNFILES_MANIFEST_FILE \
+    BAZEL=./fake_bazel.sh \
+    PATH="$build_workspace_directory/bazel-out/bazel_env-opt/bin/bazel_env/bin:/bin:/usr/bin$extra_path" \
+    $cmd 2>&1
 }
 
 #### Status script ####
@@ -154,6 +170,51 @@ assert_cmd_output "python --version" "Python 3.11.8"
 # python_tool has its own watch_files, so first call triggers rebuild.
 assert_cmd_output "python_tool" "Detected changes in watched files, rebuilding bazel_env..." ":$(dirname "$(which python3)")"
 assert_cmd_output "python_tool" "python_tool version 0.0.1" ":$(dirname "$(which python3)")"
+
+#### Stale runfiles ####
+
+python_tool_path="$build_workspace_directory/bazel-out/bazel_env-opt/bin/bazel_env/bin/python_tool"
+python_tool_runfiles_dir="$python_tool_path.runfiles/_main"
+python_tool_runfile="$python_tool_runfiles_dir/python_tool.py"
+python_tool_manifest="$python_tool_path.runfiles_manifest"
+module_bazel_backup=$(mktemp)
+cp "$build_workspace_directory/MODULE.bazel" "$module_bazel_backup"
+
+expected_python_tool_target="$(awk '$1 == "_main/python_tool.py" { print $2 }' "$python_tool_manifest")"
+if [[ -z "$expected_python_tool_target" ]]; then
+  echo "python_tool.runfiles_manifest did not contain _main/python_tool.py"
+  exit 1
+fi
+
+chmod u+w "$python_tool_runfiles_dir"
+rm "$python_tool_runfile"
+ln -s /does/not/exist "$python_tool_runfile"
+
+# Touching a watched file forces the bazel_env launcher down its rebuild path.
+# Even if the rebuild command itself succeeds, bazel_env should not re-exec a
+# wrapper whose runfiles tree is still stale.
+printf '\n# stale runfiles test\n' >> "$build_workspace_directory/MODULE.bazel"
+
+if stale_runfiles_output="$(run_cmd "python_tool" ":$(dirname "$(which python3)")")"; then
+  stale_runfiles_status=0
+else
+  stale_runfiles_status=$?
+fi
+
+cp "$module_bazel_backup" "$build_workspace_directory/MODULE.bazel"
+rm -f "$module_bazel_backup"
+rm -f "$python_tool_runfile"
+ln -s "$expected_python_tool_target" "$python_tool_runfile"
+
+if [[ $stale_runfiles_status -ne 0 ]]; then
+  echo "Expected bazel_env rebuild to repair stale runfiles for python_tool:"
+  echo "$stale_runfiles_output"
+  exit 1
+fi
+
+assert_contains "Detected changes in watched files, rebuilding bazel_env..." "$stale_runfiles_output"
+assert_contains "python_tool version 0.0.1" "$stale_runfiles_output"
+
 assert_cmd_output "cargo --version" "cargo 1.80.0 (376290515 2024-07-16)"
 assert_cmd_output "rustc --version" "rustc 1.80.0 (051478957 2024-07-21)"
 assert_cmd_output "rustfmt --version" "rustfmt 1.7.0-stable (0514789* 2024-07-21)"

--- a/examples/bazel_env_test.sh
+++ b/examples/bazel_env_test.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 build_workspace_directory="$(dirname "$(readlink -f MODULE.bazel)")"
+sha256sum_bin="$(command -v sha256sum 2>/dev/null || echo /sbin/sha256sum)"
 
 # This test runs against a local workspace, so clear any prior watch state.
 rm -f "$build_workspace_directory/bazel_env.lock"
@@ -205,6 +206,12 @@ cp "$module_bazel_backup" "$build_workspace_directory/MODULE.bazel"
 rm -f "$module_bazel_backup"
 rm -f "$python_tool_runfile"
 ln -s "$expected_python_tool_target" "$python_tool_runfile"
+{
+  "$sha256sum_bin" "$build_workspace_directory/MODULE.bazel"
+  "$sha256sum_bin" "$build_workspace_directory/BUILD.bazel"
+  "$sha256sum_bin" "$build_workspace_directory/python_tool.py"
+  "$sha256sum_bin" "$build_workspace_directory/python_tool_lib.py"
+} > "$build_workspace_directory/bazel_env.lock"
 
 if [[ $stale_runfiles_status -ne 0 ]]; then
   echo "Expected bazel_env rebuild to repair stale runfiles for python_tool:"

--- a/launcher.sh.tpl
+++ b/launcher.sh.tpl
@@ -42,6 +42,72 @@ _bazel__get_source_workspace_path() {
   fi
 }
 
+_bazel__repair_runfiles() {
+  local runfiles_dir="$1"
+  local manifest="$2"
+
+  if [[ ! -f "$manifest" ]]; then
+    return
+  fi
+
+  mkdir -p "$runfiles_dir"
+
+  local manifest_link="$runfiles_dir/MANIFEST"
+  if [[ ! -L "$manifest_link" || "$(readlink "$manifest_link" || true)" != "$manifest" ]]; then
+    rm -rf "$manifest_link"
+    ln -s "$manifest" "$manifest_link"
+  fi
+
+  local line=""
+  local rlocation=""
+  local target=""
+  local destination=""
+  local current_target=""
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -n "$line" ]] || continue
+
+    if [[ "$line" == ' '* ]]; then
+      line="${line# }"
+    fi
+
+    rlocation="${line%% *}"
+    if [[ "$line" == "$rlocation" ]]; then
+      target=""
+    else
+      target="${line#"$rlocation "}"
+    fi
+
+    rlocation="${rlocation//\\s/ }"
+    rlocation="${rlocation//\\n/$'\n'}"
+    rlocation="${rlocation//\\r/$'\r'}"
+    rlocation="${rlocation//\\t/$'\t'}"
+    rlocation="${rlocation//\\b/$'\b'}"
+    rlocation="${rlocation//\\\\/\\}"
+
+    destination="$runfiles_dir/$rlocation"
+    mkdir -p "$(dirname "$destination")"
+
+    if [[ -z "$target" ]]; then
+      if [[ -L "$destination" || -d "$destination" ]]; then
+        rm -rf "$destination"
+      fi
+      if [[ ! -f "$destination" ]]; then
+        : > "$destination"
+      fi
+      continue
+    fi
+
+    current_target=""
+    if [[ -L "$destination" ]]; then
+      current_target="$(readlink "$destination" || true)"
+    fi
+    if [[ ! -L "$destination" || "$current_target" != "$target" ]]; then
+      rm -rf "$destination"
+      ln -s "$target" "$destination"
+    fi
+  done < "$manifest"
+}
+
 case "${BASH_SOURCE[0]}" in
   /*) own_path="${BASH_SOURCE[0]}" ;;
   *) own_path="$PWD/${BASH_SOURCE[0]}" ;;
@@ -172,6 +238,9 @@ if [[ $rebuild_env == True && "${BAZEL_ENV_INTERNAL_EXEC:-False}" != True ]]; th
   ' <(printf "%s\n" "${files_to_watch[@]}") "$lock_file" > "$tmp" 2>/dev/null || true
   "$sha256_cmd" "${files_to_watch[@]}" >> "$tmp"
   mv "$tmp" "$lock_file"
+  # If Bazel reused cached outputs, the wrapper's runfiles tree may still be stale.
+  # Rehydrate it from the manifest before re-execing this tool.
+  _bazel__repair_runfiles "${own_path}.runfiles" "${own_path}.runfiles_manifest"
   BAZEL_ENV_INTERNAL_EXEC=True exec "$own_path" "$@"
 fi
 


### PR DESCRIPTION
Disclaimer:  I used AI heavily to debug the issue and write this PR.

## Problem

When a watched file changes, the launcher runs `bazel build //:bazel_env` and then immediately re-execs the current wrapper.

If Bazel reports the target as up to date and reuses cached outputs, the wrapper's existing `*.runfiles` tree can still be stale. In that case the launcher re-execs a broken wrapper and the tool fails even though the rebuild path completed successfully.

The new regression test reproduces this by corrupting `python_tool.runfiles/_main/python_tool.py`, touching a watched file, and asserting that `python_tool` still succeeds.

## Fix

Before re-execing in the watched-file rebuild path, rehydrate the current wrapper's runfiles tree from its `*.runfiles_manifest`.

This makes the launcher resilient when Bazel reuses cached outputs instead of restaging the wrapper runfiles directory.

## Testing

- `bazel test //:bazel_env_test`