### PR TITLE
Replace `touch` with bash builtin to fix NixOS compatibility

### DIFF
--- a/bazel_env.bzl
+++ b/bazel_env.bzl
@@ -410,9 +410,11 @@ def _bazel_env_rule_impl(ctx):
         outputs = [implicit_out],
         inputs = depset(direct_inputs, transitive = transitive_inputs),
         tools = tools,
-        command = """
-        touch "$1"
-        """,
+        # Use the bash builtin `:` (true) with output redirection instead of
+        # `touch`, which is an external command that requires PATH. Unpatched
+        # Bazel binaries (e.g. via bazelisk on NixOS) run shell actions with a
+        # stripped environment where external commands are not available.
+        command = """: > "$1" """,
         arguments = [implicit_out.path],
         # Run this action locally to force the runfiles directories for the tools to be created even
         # with --nobuild_runfile_links.
@@ -658,8 +660,9 @@ def bazel_env(*, name, tools = {}, toolchains = {}, watch_dirs = {}, watch_files
             name = toolchain_genrule_name,
             outs = [toolchain_genrule_name + ".txt"],
             # This genrule is never built and tagged as manual, but if a user
-            # ends up requesting it, it should not fail.
-            cmd = "touch $@",
+            # ends up requesting it, it should not fail. Use the bash builtin
+            # `:` instead of `touch` to avoid depending on PATH.
+            cmd = ": > $@",
             toolchains = [toolchain],
             visibility = ["//visibility:private"],
             tags = [


### PR DESCRIPTION
## Summary

- Replace `touch "$1"` with `: > "$1"` in `_bazel_env_rule_impl`
- Replace `touch $@` with `: > $@` in the toolchain genrule

## Problem

Fixes #100.

`bazel_env` fails on NixOS when using bazelisk (unpatched Bazel binaries). Bazel runs `run_shell` actions with a stripped environment (`exec env -`), so `touch` — an external command — is not found. On NixOS, tools live in the Nix store and are only reachable via `PATH`.

## Fix

`: >` is a bash builtin (`:` is equivalent to `true`) combined with output redirection, which creates/truncates a file identically to `touch` without requiring any external command on `PATH`. This is a no-op change on other platforms.

Tested locally: 26/27 → 27/27 targets building with bazelisk on NixOS.

This PR was entirely vibe coded with [Claude Code](https://claude.ai/code).