### PR TITLE
Delete fake module version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,5 @@
 module(
     name = "bazel_env.bzl",
-    version = "0.0.0",
     bazel_compatibility = [">=7.0.2"],
 )
 


### PR DESCRIPTION
The correct version is patched in during the release process and the empty string sorts correctly (highest possible version).