### PR TITLE
Support BusyBox sha256sum checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,10 @@ jobs:
           USE_BAZEL_VERSION: ${{ matrix.bazel }}
         working-directory: ./examples
         # Build first because the tests rely on convenience symlinks.
-        run: bazelisk build //... && bazelisk test //...
+        run: |
+          bazelisk build //...
+          bazelisk test //...
+          bazelisk test --extra_execution_platforms=@platforms//host //:bazel_env_test
 
       - name: Sanitize Bazel version
         if: always()

--- a/examples/bazel_env_test.sh
+++ b/examples/bazel_env_test.sh
@@ -134,6 +134,9 @@ diff <(expected_output "$BAZEL_REPO_NAME_SEPARATOR" "$TOOLCHAIN_TYPES_SUPPORTED"
 
 #### Tools ####
 
+# Ensure repeated test configurations begin with the same auto-rebuild state.
+rm -f "$build_workspace_directory/bazel_env.lock"
+
 # First call to any bazel_env tool will trigger rebuild
 assert_cmd_output "bazel-cc --version" "Detected changes in watched files, rebuilding bazel_env..."
 assert_cmd_output "bazel-cc --version" "@(*gcc*|*clang*)"

--- a/launcher.sh.tpl
+++ b/launcher.sh.tpl
@@ -100,6 +100,10 @@ fi
 
 rebuild_env=False
 sha256_cmd="${own_path}.runfiles/{{sha256sum_rlocation_path}}"
+sha256_status_option="-s"
+if ! "$sha256_cmd" -c "$sha256_status_option" /dev/null 2>/dev/null; then
+  sha256_status_option="--status"
+fi
 
 if [[ ${#files_to_watch[@]} -gt 0 ]]; then
   lock_file="$watch_base/bazel_env.lock"
@@ -124,7 +128,7 @@ if [[ ${#files_to_watch[@]} -gt 0 ]]; then
   fi
 
   if [[ $matched_count -eq ${#files_to_watch[@]} ]]; then
-    if echo "$matched_lines" | "$sha256_cmd" -c --status - 2>/dev/null; then
+    if echo "$matched_lines" | "$sha256_cmd" -c "$sha256_status_option" - 2>/dev/null; then
       rebuild_env=False
     else
       rebuild_env=True
@@ -149,7 +153,7 @@ if [[ $rebuild_env == True && "${BAZEL_ENV_INTERNAL_EXEC:-False}" != True ]]; th
         ' "$lock_file" 2>/dev/null || true)
 
         if [[ -n "$matched_line" ]]; then
-          if ! echo "$matched_line" | "$sha256_cmd" -c --status - 2>/dev/null; then
+          if ! echo "$matched_line" | "$sha256_cmd" -c "$sha256_status_option" - 2>/dev/null; then
             echo "  - $file (modified)" >&2
           fi
         else

--- a/launcher.sh.tpl
+++ b/launcher.sh.tpl
@@ -100,10 +100,6 @@ fi
 
 rebuild_env=False
 sha256_cmd="${own_path}.runfiles/{{sha256sum_rlocation_path}}"
-sha256_status_option="-s"
-if ! "$sha256_cmd" -c "$sha256_status_option" /dev/null 2>/dev/null; then
-  sha256_status_option="--status"
-fi
 
 if [[ ${#files_to_watch[@]} -gt 0 ]]; then
   lock_file="$watch_base/bazel_env.lock"
@@ -128,7 +124,7 @@ if [[ ${#files_to_watch[@]} -gt 0 ]]; then
   fi
 
   if [[ $matched_count -eq ${#files_to_watch[@]} ]]; then
-    if echo "$matched_lines" | "$sha256_cmd" -c "$sha256_status_option" - 2>/dev/null; then
+    if echo "$matched_lines" | "$sha256_cmd" -c - >/dev/null 2>&1; then
       rebuild_env=False
     else
       rebuild_env=True
@@ -153,7 +149,7 @@ if [[ $rebuild_env == True && "${BAZEL_ENV_INTERNAL_EXEC:-False}" != True ]]; th
         ' "$lock_file" 2>/dev/null || true)
 
         if [[ -n "$matched_line" ]]; then
-          if ! echo "$matched_line" | "$sha256_cmd" -c "$sha256_status_option" - 2>/dev/null; then
+          if ! echo "$matched_line" | "$sha256_cmd" -c - >/dev/null 2>&1; then
             echo "  - $file (modified)" >&2
           fi
         else


### PR DESCRIPTION
AI-written, human-reviewed.

Fixes #108.

## What changed

- Use the common `sha256sum -c` interface and discard verification output through shell redirection.
- Reset the example's watch lock so repeated configurations start deterministically.
- Run the example regression under both its default execution platform and the host execution platform, which selects BusyBox on Linux.

## Why

`rules_coreutils` can resolve either GNU or BusyBox `sha256sum`. BusyBox rejects GNU's `--status` option, causing a successful checksum comparison to return status 1 and making every watched tool invocation rebuild `bazel_env`. Both implementations support `-c`, and shell redirection preserves the existing exit-status-only behavior without implementation-specific options.

## Validation

- `bazel test //...`
- `cd examples && bazel build //...`
- `cd examples && bazel test //...`
- `cd examples && bazel test --extra_execution_platforms=@platforms//host //:bazel_env_test`