### PR TITLE
Force an exotic execution platform more thoroughly in tests

### DIFF
--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -8,9 +8,7 @@ common --incompatible_disallow_empty_glob
 common --incompatible_strict_action_env
 common --nolegacy_external_runfiles
 common --nobuild_runfile_links
-# TODO: Uncomment this when it no longer crashes Bazel
-# https://github.com/bazelbuild/bazel/pull/25999
-# common --extra_execution_platforms=//:exotic_platform
+common --extra_execution_platforms=//:exotic_platform
 
 # Test that the platform suffix still results in expected output directory for tools.
 common --enable_platform_specific_config


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/pull/25999 has been fixed in all tested versions of Bazel.