### PR TITLE
Repair stale runfiles trees during auto-rebuild

### DIFF
--- a/bazel_env.bzl
+++ b/bazel_env.bzl
@@ -291,11 +291,22 @@ def _tool_impl(ctx):
 
     runfiles = runfiles.merge(sha256sum.default_runfiles)
 
+    # Path of the helper action output of the bazel_env target (see
+    # _bazel_env_rule_impl) relative to the directory containing the launcher.
+    # It is built from ".." segments instead of stripping path suffixes so
+    # that it also resolves correctly if the launcher is invoked through a
+    # symlink to the bin directory.
+    bazel_env_name = ctx.label.name.removesuffix("/tools/" + name)
+    all_tools_path = "/".join(
+        [".."] * (2 + bazel_env_name.count("/")) + [bazel_env_name + "_all_tools"],
+    )
+
     ctx.actions.expand_template(
         template = ctx.file._launcher,
         output = out,
         is_executable = True,
         substitutions = {
+            "{{all_tools_path}}": all_tools_path,
             "{{bazel_env_label}}": str(ctx.label).removeprefix("@@").removesuffix("/tools/" + name),
             "{{rlocation_path}}": rlocation_path,
             "{{sha256sum_rlocation_path}}": _rlocation_path(ctx, sha256sum.executable),
@@ -438,6 +449,10 @@ done
 
 def _bazel_env_rule_impl(ctx):
     # type: (ctx) -> list[Provider]
+    # The launcher deletes this output before an auto-rebuild to force the
+    # action below to re-execute, which makes Bazel re-verify the runfiles
+    # trees of all tools. Keep the name in sync with the {{all_tools_path}}
+    # substitution in _tool_impl.
     implicit_out = ctx.actions.declare_file(ctx.label.name + "_all_tools")
 
     # It is not necessary to stage the toolchain files (which are in runfiles) as inputs as their

--- a/examples/bazel_env_test.sh
+++ b/examples/bazel_env_test.sh
@@ -263,3 +263,52 @@ if grep -qF "Fake Bazel stdout" "$rebuild_stdout"; then
   exit 1
 fi
 assert_contains "buildifier version:" "$(cat "$rebuild_stdout")"
+
+#### Auto-rebuild re-materializes runfiles trees ####
+
+# The runfiles trees of the tools are only (re-)created when the bazel_env
+# target's helper action actually executes. On a fully cached build, Bazel
+# skips the action and never re-verifies the trees, so externally corrupted
+# runfiles (e.g. after a cache cleaner ran over the output base) would stay
+# broken forever. The launcher must therefore delete the helper action's
+# output before invoking bazel so that the action re-executes and Bazel
+# itself repairs the runfiles trees of all tools.
+
+all_tools_out="$build_workspace_directory/bazel-out/bazel_env-opt/bin/bazel_env_all_tools"
+# The rebuilds triggered earlier in this test already deleted the helper
+# action's output and the fake bazel doesn't recreate it. Recreate it here to
+# verify that the launcher deletes it before invoking bazel.
+rm -f "$all_tools_out"
+: > "$all_tools_out"
+
+# Remove the lock file to force a rebuild on the next tool invocation.
+rm -f "$build_workspace_directory/bazel_env.lock"
+
+observation_file=$(mktemp)
+repair_marker=$(mktemp)
+trap 'rm -f "$rebuild_stdout" "$rebuild_stderr" "$rebuild_marker" "$observation_file" "$repair_marker"' EXIT
+
+repair_output=$(env \
+    -u TEST_SRCDIR \
+    -u RUNFILES_DIR \
+    -u RUNFILES_MANIFEST_FILE \
+    FAKE_BAZEL_MARKER_FILE="$repair_marker" \
+    FAKE_BAZEL_OBSERVED_FILE="$all_tools_out" \
+    FAKE_BAZEL_OBSERVATION_FILE="$observation_file" \
+    BAZEL=./fake_bazel.sh \
+    PATH="$build_workspace_directory/bazel-out/bazel_env-opt/bin/bazel_env/bin:/bin:/usr/bin" \
+    buildifier --version 2>&1) || {
+  echo "buildifier --version failed during rebuild:"
+  echo "$repair_output"
+  exit 1
+}
+
+# Sanity check: a rebuild actually happened (otherwise this test is vacuous).
+assert_contains "Detected changes in watched files, rebuilding bazel_env..." "$repair_output"
+
+# The launcher must have deleted the helper action's output before invoking
+# bazel so that the action re-executes even on an otherwise fully cached build.
+if [[ "$(cat "$observation_file")" != "absent" ]]; then
+  echo "Expected the launcher to delete $all_tools_out before invoking bazel, but it still existed"
+  exit 1
+fi

--- a/examples/fake_bazel.sh
+++ b/examples/fake_bazel.sh
@@ -10,4 +10,14 @@ fi
 echo "Fake Bazel stdout"
 echo "Fake Bazel stderr" >&2
 echo "1" >> "${FAKE_BAZEL_MARKER_FILE:-/dev/null}"
+
+# Record whether a given file existed at the time of the invocation.
+if [[ -n "${FAKE_BAZEL_OBSERVED_FILE:-}" ]]; then
+  if [[ -e "$FAKE_BAZEL_OBSERVED_FILE" ]]; then
+    echo "present" >> "${FAKE_BAZEL_OBSERVATION_FILE:-/dev/null}"
+  else
+    echo "absent" >> "${FAKE_BAZEL_OBSERVATION_FILE:-/dev/null}"
+  fi
+fi
+
 exit "${FAKE_BAZEL_EXIT_CODE:-0}"

--- a/launcher.sh.tpl
+++ b/launcher.sh.tpl
@@ -154,6 +154,13 @@ if [[ $rebuild_env == True && "${BAZEL_ENV_INTERNAL_EXEC:-False}" != True ]]; th
       fi
     done
   fi
+  # The runfiles trees of the tools are only (re-)created when the bazel_env
+  # target's helper action actually executes, which it doesn't if the build is
+  # an incremental action cache hit (its no-cache tag only disables the remote
+  # and disk caches). Delete its output so that the build below re-executes it
+  # and Bazel re-verifies and, if necessary, repairs the runfiles trees of all
+  # tools, e.g. after a cache cleaner deleted files from the output base.
+  rm -f "${own_dir}/{{all_tools_path}}"
   # Run bazel from the source workspace to ensure it can find the WORKSPACE/MODULE file.
   # Redirect stdout to stderr so build logs don't pollute stdout and break piping.
   (cd "$watch_base" && "${BAZEL:-bazel}" build {{bazel_env_label}} >&2)


### PR DESCRIPTION
## Problem

When files inside a tool's `*.runfiles` tree under `bazel-out/bazel_env-opt/bin` are deleted or corrupted outside of Bazel (e.g. by a cache cleaner sweeping the output base, which lives under `~/Library/Caches` by default on macOS), the tool breaks and never recovers: the launcher's auto-rebuild runs `bazel build`, the build succeeds as a fully cached no-op, and the launcher re-execs the still-broken wrapper. This is the symptom reported in #99.

Reproduction with a real Bazel in `examples/` (no fake bazel involved):

```sh
bazel build //:bazel_env
# Seed bazel_env.lock by running any watched tool once, then:
rf=bazel-out/bazel_env-opt/bin/bazel_env/bin/python_tool.runfiles/_main/python_tool.py
chmod u+w "$(dirname "$rf")" && rm "$rf" && ln -s /does/not/exist "$rf"
printf '\n# comment\n' >> MODULE.bazel
PATH="$PWD/bazel-out/bazel_env-opt/bin/bazel_env/bin:$PATH" python_tool
# -> "Detected changes in watched files, rebuilding bazel_env..." followed by
#    "AssertionError: Cannot exec() '.../python_tool.py': file not found."
```

## Root cause

The runfiles trees of the tools are only materialized as a side effect of *executing* the `<name>_all_tools` helper action, which runs locally with every tool's `files_to_run` as inputs. Its `no-cache`/`no-remote` execution requirements disable the remote and disk caches, but not Bazel's incremental action cache: on any build in which the action's inputs are unchanged — exactly the "up to date" case hit by the auto-rebuild — the action is skipped and the runfiles trees are never even looked at, so external damage persists indefinitely.

Experimentally, whenever the helper action does re-execute, Bazel re-verifies and repairs the runfiles trees of *all* tools, including trees whose runfiles manifests didn't change.

## Fix

Before running `bazel build` on the auto-rebuild path, the launcher now deletes the helper action's declared output (`<name>_all_tools`). Bazel re-executes actions whose declared outputs are missing, so the rebuild re-materializes and repairs every tool's runfiles tree using Bazel's own logic — no reimplementation of runfiles staging needed. The cost is one re-execution of a trivial local action, only on the (already `bazel build`-sized) rebuild path.

The marker path is passed to the launcher as a template substitution built from `..` segments rather than derived by stripping suffixes from the launcher's own path, so it also resolves correctly if the launcher is ever invoked through a symlink to the bin directory.

The regression test extends `fake_bazel.sh` to record whether the helper action's output still existed at the moment the launcher invoked `bazel build`, and asserts that it had already been deleted. (With the fake bazel the repair itself can't be observed in the test; that part was verified manually with a real Bazel using the reproduction above, which now self-heals: the rebuild repairs the symlink and the tool prints its version.)

## Relationship to #99

#99 addresses the same symptom by rehydrating the invoked tool's runfiles tree from its manifest in ~65 lines of bash in the launcher. That repairs only the invoked tool, only on the watched-files rebuild path, and has to track Bazel's manifest escaping/staging semantics. This PR instead makes the existing rebuild re-execute the action whose job it is to materialize the trees, so Bazel repairs all tools' trees itself. Thanks @danielepolencic for the report and the investigation that pinpointed the failure mode!

## Possible follow-up

The launcher could additionally delete the marker and retry once when its final exec target turns out to be missing, which would also cover corrupted trees in setups that don't use `watch_files`/`watch_dirs` at all.

Closes #99
