### PR TITLE
Resolve sha256sum for the host platform and support BusyBox sha256sum

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,8 +1,16 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load(":sha256sum_tool.bzl", "sha256sum_tool")
+
+sha256sum_tool(
+    name = "sha256sum_tool",
+)
 
 bzl_library(
     name = "bazel_env",
-    srcs = ["bazel_env.bzl"],
+    srcs = [
+        "bazel_env.bzl",
+        "sha256sum_tool.bzl",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "@bazel_features//:features",

--- a/bazel_env.bzl
+++ b/bazel_env.bzl
@@ -1,5 +1,6 @@
 load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load(":sha256sum_tool.bzl", _Sha256sumInfo = "Sha256sumInfo")
 
 def _rlocation_path(ctx, file):
     # type: (ctx, File) -> string
@@ -247,8 +248,6 @@ def _shell_quote(s):
     # type: (string) -> string
     return "'" + s.replace("'", "'\\''") + "'"
 
-_SHA256SUM_TOOLCHAIN_TYPE = "@rules_coreutils//coreutils/toolchain/sha256sum:type"
-
 def _tool_impl(ctx):
     # type: (ctx) -> list[Provider]
     name = ctx.label.name.rpartition("/")[-1]
@@ -286,9 +285,9 @@ def _tool_impl(ctx):
         if _BinaryArgsInfo in target:
             extra_args = target[_BinaryArgsInfo].args
 
-    sha256sum = ctx.toolchains[_SHA256SUM_TOOLCHAIN_TYPE]
+    sha256sum = ctx.attr._sha256sum[0][_Sha256sumInfo]
 
-    runfiles = runfiles.merge(sha256sum.default.default_runfiles)
+    runfiles = runfiles.merge(sha256sum.default_runfiles)
 
     ctx.actions.expand_template(
         template = ctx.file._launcher,
@@ -297,7 +296,7 @@ def _tool_impl(ctx):
         substitutions = {
             "{{bazel_env_label}}": str(ctx.label).removeprefix("@@").removesuffix("/bin/" + name),
             "{{rlocation_path}}": rlocation_path,
-            "{{sha256sum_rlocation_path}}": _rlocation_path(ctx, sha256sum.run.executable),
+            "{{sha256sum_rlocation_path}}": _rlocation_path(ctx, sha256sum.executable),
             "{{extra_env}}": "\n".join([
                 "export {}={}".format(k, repr(v))
                 for k, v in extra_env.items()
@@ -338,9 +337,17 @@ _tool = rule(
             default = ":launcher.sh.tpl",
             executable = True,
         ),
+        # The launcher runs sha256sum on the host machine, so its toolchain has to be resolved
+        # with the host platform as the highest-precedence execution platform. _tool itself can't
+        # force this via its own configuration without adding an ST hash to the "bazel_env-opt"
+        # output directory, so it instead depends on the resolving rule via the _flip_output_dir
+        # transition, which restores the host platform's precedence.
+        "_sha256sum": attr.label(
+            cfg = _flip_output_dir,
+            default = ":sha256sum_tool",
+        ),
     },
     executable = True,
-    toolchains = [_SHA256SUM_TOOLCHAIN_TYPE],
 )
 
 def _toolchain_impl(ctx):

--- a/examples/bazel_env_test.sh
+++ b/examples/bazel_env_test.sh
@@ -134,6 +134,9 @@ diff <(expected_output "$BAZEL_REPO_NAME_SEPARATOR" "$TOOLCHAIN_TYPES_SUPPORTED"
 
 #### Tools ####
 
+# Ensure repeated test configurations begin with the same auto-rebuild state.
+rm -f "$build_workspace_directory/bazel_env.lock"
+
 # First call to any bazel_env tool will trigger rebuild
 assert_cmd_output "bazel-cc --version" "Detected changes in watched files, rebuilding bazel_env..."
 assert_cmd_output "bazel-cc --version" "@(*gcc*|*clang*)"

--- a/launcher.sh.tpl
+++ b/launcher.sh.tpl
@@ -124,7 +124,7 @@ if [[ ${#files_to_watch[@]} -gt 0 ]]; then
   fi
 
   if [[ $matched_count -eq ${#files_to_watch[@]} ]]; then
-    if echo "$matched_lines" | "$sha256_cmd" -c --status - 2>/dev/null; then
+    if echo "$matched_lines" | "$sha256_cmd" -c - >/dev/null 2>&1; then
       rebuild_env=False
     else
       rebuild_env=True
@@ -149,7 +149,7 @@ if [[ $rebuild_env == True && "${BAZEL_ENV_INTERNAL_EXEC:-False}" != True ]]; th
         ' "$lock_file" 2>/dev/null || true)
 
         if [[ -n "$matched_line" ]]; then
-          if ! echo "$matched_line" | "$sha256_cmd" -c --status - 2>/dev/null; then
+          if ! echo "$matched_line" | "$sha256_cmd" -c - >/dev/null 2>&1; then
             echo "  - $file (modified)" >&2
           fi
         else

--- a/sha256sum_tool.bzl
+++ b/sha256sum_tool.bzl
@@ -1,0 +1,20 @@
+"""Helper resolving the sha256sum toolchain used by tool launchers."""
+
+visibility("private")
+
+_SHA256SUM_TOOLCHAIN_TYPE = Label("@rules_coreutils//coreutils/toolchain/sha256sum:type")
+
+Sha256sumInfo = provider(fields = ["executable", "default_runfiles"])
+
+def _sha256sum_tool_impl(ctx):
+    # type: (ctx) -> list[Provider]
+    sha256sum = ctx.toolchains[_SHA256SUM_TOOLCHAIN_TYPE]
+    return [Sha256sumInfo(
+        executable = sha256sum.run.executable,
+        default_runfiles = sha256sum.default.default_runfiles,
+    )]
+
+sha256sum_tool = rule(
+    implementation = _sha256sum_tool_impl,
+    toolchains = [_SHA256SUM_TOOLCHAIN_TYPE],
+)


### PR DESCRIPTION
The launcher runs `sha256sum` on the host machine, but its toolchain was resolved under the user's execution platform order. This could select a tool that doesn't run on the host or, as in the examples with their registered exotic execution platform, the non-hermetic `local` fallback from the `PATH`. The toolchain is now resolved behind the `_flip_output_dir` transition, which already gives the host platform the highest precedence for exactly this reason. `_tool` itself can't force this in its own configuration without picking up an ST hash on the fixed `bazel_env-opt` output directory, hence the helper rule.

On Linux, resolution now picks BusyBox's `sha256sum` by default, which rejects GNU's `--status` option and made every watched tool invocation rebuild `bazel_env`. This PR thus also includes the portable `sha256sum -c -` invocation and the test lock reset from #109 (thanks @TrapsterDK, credited as co-author): since the default configuration now selects BusyBox on Linux CI, the extra `--extra_execution_platforms=@platforms//host` test invocation proposed there is no longer needed.

Closes #109
Fixes #108
