### PR TITLE
Refresh bazel_env.lock on bazel run to avoid a first-use rebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ MODULE.bazel.lock
 .ijwb
 .idea
 bazel_env.lock
+bazel_env.lock.*

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -27,6 +27,7 @@ exports_files(
     [
         "status.sh.tpl",
         "launcher.sh.tpl",
+        "lock_lib.sh",
     ],
     visibility = ["//visibility:private"],
 )

--- a/bazel_env.bzl
+++ b/bazel_env.bzl
@@ -290,6 +290,7 @@ def _tool_impl(ctx):
     sha256sum = ctx.attr._sha256sum[0][_Sha256sumInfo]
 
     runfiles = runfiles.merge(sha256sum.default_runfiles)
+    runfiles = runfiles.merge(ctx.runfiles([ctx.file._lock_lib]))
 
     # Path of the helper action output of the bazel_env target (see
     # _bazel_env_rule_impl) relative to the directory containing the launcher.
@@ -310,6 +311,7 @@ def _tool_impl(ctx):
             "{{bazel_env_label}}": str(ctx.label).removeprefix("@@").removesuffix("/tools/" + name),
             "{{rlocation_path}}": rlocation_path,
             "{{sha256sum_rlocation_path}}": _rlocation_path(ctx, sha256sum.executable),
+            "{{lock_lib_rlocation_path}}": _rlocation_path(ctx, ctx.file._lock_lib),
             "{{extra_env}}": "\n".join([
                 "export {}={}".format(k, repr(v))
                 for k, v in extra_env.items()
@@ -358,6 +360,11 @@ _tool = rule(
         "_sha256sum": attr.label(
             cfg = _flip_output_dir,
             default = ":sha256sum_tool",
+        ),
+        "_lock_lib": attr.label(
+            allow_single_file = True,
+            cfg = _flip_output_dir,
+            default = ":lock_lib.sh",
         ),
     },
     executable = True,
@@ -508,6 +515,8 @@ def _bazel_env_rule_impl(ctx):
     ) for toolchain in ctx.attr.toolchain_targets]
     toolchain_name_pad = max([len(toolchain_info.name) for toolchain_info in toolchain_infos] + [0])
 
+    sha256sum = ctx.attr._sha256sum[0][_Sha256sumInfo]
+
     status_script = ctx.actions.declare_file(ctx.label.name + ".sh")
     ctx.actions.expand_template(
         template = ctx.file._status,
@@ -519,6 +528,9 @@ def _bazel_env_rule_impl(ctx):
             # //:bazel_env
             "{{label}}": str(ctx.label).removeprefix("@@"),
             "{{bin_dir}}": bin_dir.path,
+            "{{tools_dir}}": bin_dir.path.removesuffix("/bin") + "/tools",
+            "{{sha256sum_rlocation_path}}": _rlocation_path(ctx, sha256sum.executable),
+            "{{lock_lib_rlocation_path}}": _rlocation_path(ctx, ctx.file._lock_lib),
             "{{unique_name_tool}}": ctx.attr.unique_marker_name,
             "{{has_tools}}": str(bool(tool_infos)),
             "{{tools}}": "\n".join(
@@ -541,6 +553,7 @@ def _bazel_env_rule_impl(ctx):
         DefaultInfo(
             executable = status_script,
             files = depset([implicit_out, bin_dir]),
+            runfiles = ctx.runfiles([ctx.file._lock_lib]).merge(sha256sum.default_runfiles),
         ),
     ]
 
@@ -562,6 +575,15 @@ _bazel_env_rule = rule(
             cfg = "target",
             default = ":status.sh.tpl",
             executable = True,
+        ),
+        "_sha256sum": attr.label(
+            cfg = _flip_output_dir,
+            default = ":sha256sum_tool",
+        ),
+        "_lock_lib": attr.label(
+            allow_single_file = True,
+            cfg = "target",
+            default = ":lock_lib.sh",
         ),
     },
     executable = True,

--- a/bazel_env.bzl
+++ b/bazel_env.bzl
@@ -517,6 +517,8 @@ def _bazel_env_rule_impl(ctx):
 
     sha256sum = ctx.attr._sha256sum[0][_Sha256sumInfo]
 
+    watch_list_files = ctx.files.tool_dirs + ctx.files.tool_files
+
     status_script = ctx.actions.declare_file(ctx.label.name + ".sh")
     ctx.actions.expand_template(
         template = ctx.file._status,
@@ -528,9 +530,9 @@ def _bazel_env_rule_impl(ctx):
             # //:bazel_env
             "{{label}}": str(ctx.label).removeprefix("@@"),
             "{{bin_dir}}": bin_dir.path,
-            "{{tools_dir}}": bin_dir.path.removesuffix("/bin") + "/tools",
             "{{sha256sum_rlocation_path}}": _rlocation_path(ctx, sha256sum.executable),
             "{{lock_lib_rlocation_path}}": _rlocation_path(ctx, ctx.file._lock_lib),
+            "{{watch_list_rlocation_paths}}": "\n".join([_rlocation_path(ctx, f) for f in watch_list_files]),
             "{{unique_name_tool}}": ctx.attr.unique_marker_name,
             "{{has_tools}}": str(bool(tool_infos)),
             "{{tools}}": "\n".join(
@@ -553,7 +555,7 @@ def _bazel_env_rule_impl(ctx):
         DefaultInfo(
             executable = status_script,
             files = depset([implicit_out, bin_dir]),
-            runfiles = ctx.runfiles([ctx.file._lock_lib]).merge(sha256sum.default_runfiles),
+            runfiles = ctx.runfiles([ctx.file._lock_lib] + watch_list_files).merge(sha256sum.default_runfiles),
         ),
     ]
 

--- a/examples/bazel_env_test.sh
+++ b/examples/bazel_env_test.sh
@@ -165,6 +165,17 @@ fi
 # our own watched file must still be present (refreshed)
 assert_contains "$build_workspace_directory/MODULE.bazel" "$(cat "$lock_file")"
 
+#### Seed suppresses the first-use rebuild ####
+assert_cmd_output "buildifier --version" "buildifier version: 7.3.1 "
+
+#### A watched-file change after seeding still rebuilds ####
+
+corrupt=$(mktemp)
+awk -v f="$build_workspace_directory/MODULE.bazel" '
+  { match($0, /^[^ ]+ +/); p = substr($0, RSTART + RLENGTH); if (p == f) $0 = "0000000000000000000000000000000000000000000000000000000000000000  " f; print }
+' "$lock_file" > "$corrupt" && mv "$corrupt" "$lock_file"
+assert_cmd_output "buildifier --version" "Detected changes in watched files, rebuilding bazel_env..."
+
 #### Tools ####
 
 # Ensure repeated test configurations begin with the same auto-rebuild state.

--- a/examples/bazel_env_test.sh
+++ b/examples/bazel_env_test.sh
@@ -97,6 +97,7 @@ function expected_output {
 
 ✅ direnv is installed
 ✅ direnv added bazel-out/bazel_env-opt/bin/bazel_env/bin to PATH
+✅ Refreshed bazel_env.lock
 
 Tools available in PATH:
   * bazel-cc:    \$(CC)
@@ -131,6 +132,38 @@ ${toolchain_type_toolchains}
 }
 
 diff <(expected_output "$BAZEL_REPO_NAME_SEPARATOR" "$TOOLCHAIN_TYPES_SUPPORTED") <(echo "$status_out") || exit 1
+
+#### Lock seeding ####
+
+# The status script (bazel run) seeds bazel_env.lock so freshly built tools are
+# not treated as stale on their first invocation.
+# Verify it was written and covers the _common watch files.
+lock_file="$build_workspace_directory/bazel_env.lock"
+[[ -s "$lock_file" ]] || { echo "bazel_env.lock was not created or is empty"; exit 1; }
+assert_contains "$build_workspace_directory/MODULE.bazel" "$(cat "$lock_file")"
+assert_contains "$build_workspace_directory/BUILD.bazel" "$(cat "$lock_file")"
+
+#### Lock merge ####
+
+# The lock is shared by every bazel_env target in the workspace, so re-seeding
+# merges rather than overwrites: entries this run doesn't manage (e.g. another
+# bazel_env target's) must survive, and our own watched files must still be
+# present afterwards.
+foreign_path="$build_workspace_directory/other-bazel-env-entry.txt"
+printf '%s  %s\n' "0000000000000000000000000000000000000000000000000000000000000000" "$foreign_path" >> "$lock_file"
+
+PATH="$tmpdir:$build_workspace_directory/bazel-out/bazel_env-opt/bin/bazel_env/bin:/bin:/usr/bin" \
+BUILD_WORKSPACE_DIRECTORY="$build_workspace_directory" \
+  ./bazel_env.sh >/dev/null || { echo "Status re-run failed"; exit 1; }
+
+# the foreign entry (another target's) must be preserved, not clobbered
+if ! grep -qF -- "$foreign_path" "$lock_file"; then
+  echo "Re-seed clobbered an unrelated entry in bazel_env.lock:"
+  cat "$lock_file"
+  exit 1
+fi
+# our own watched file must still be present (refreshed)
+assert_contains "$build_workspace_directory/MODULE.bazel" "$(cat "$lock_file")"
 
 #### Tools ####
 

--- a/launcher.sh.tpl
+++ b/launcher.sh.tpl
@@ -58,41 +58,17 @@ files_to_watch=()
 # Fall back to workspace_path if source_workspace_path is empty.
 watch_base="${source_workspace_path:-$workspace_path}"
 
-if [[ -f "${own_dir}/__common_watch_dirs.txt" ]]; then
-  for dir in $(cat "${own_dir}/__common_watch_dirs.txt"); do
-    if [[ -d "$watch_base/$dir" ]]; then
-      for file in $(find "$watch_base/$dir" -type f); do
-        files_to_watch+=("$file")
-      done
-    fi
-  done
-fi
+# Enumerate this tool's watched files via the shared helper so the launcher and
+# the status script (bazel run) agree on the exact contents of bazel_env.lock.
+source "${own_path}.runfiles/{{lock_lib_rlocation_path}}"
 
-if [[ -f "${own_dir}/__common_watch_files.txt" ]]; then
-  for file in $(cat "${own_dir}/__common_watch_files.txt"); do
-    if [[ -f "$watch_base/$file" ]]; then
-      files_to_watch+=("$watch_base/$file")
-    fi
-  done
-fi
-
-if [[ -f "${own_dir}/_${own_name}_watch_dirs.txt" ]]; then
-  for dir in $(cat "${own_dir}/_${own_name}_watch_dirs.txt"); do
-    if [[ -d "$watch_base/$dir" ]]; then
-      for file in $(find "$watch_base/$dir" -type f); do
-        files_to_watch+=("$file")
-      done
-    fi
-  done
-fi
-
-if [[ -f "${own_dir}/_${own_name}_watch_files.txt" ]]; then
-  for file in $(cat "${own_dir}/_${own_name}_watch_files.txt"); do
-    if [[ -f "$watch_base/$file" ]]; then
-      files_to_watch+=("$watch_base/$file")
-    fi
-  done
-fi
+while IFS= read -r _watch_file; do
+  files_to_watch+=("$_watch_file")
+done < <(bazel_env_collect_watch_files "$watch_base" \
+  "${own_dir}/__common_watch_dirs.txt" \
+  "${own_dir}/__common_watch_files.txt" \
+  "${own_dir}/_${own_name}_watch_dirs.txt" \
+  "${own_dir}/_${own_name}_watch_files.txt")
 
 rebuild_env=False
 sha256_cmd="${own_path}.runfiles/{{sha256sum_rlocation_path}}"

--- a/launcher.sh.tpl
+++ b/launcher.sh.tpl
@@ -140,18 +140,7 @@ if [[ $rebuild_env == True && "${BAZEL_ENV_INTERNAL_EXEC:-False}" != True ]]; th
   # Run bazel from the source workspace to ensure it can find the WORKSPACE/MODULE file.
   # Redirect stdout to stderr so build logs don't pollute stdout and break piping.
   (cd "$watch_base" && "${BAZEL:-bazel}" build {{bazel_env_label}} >&2)
-  tmp=$(mktemp)
-  trap 'rm -f "$tmp"' EXIT INT TERM
-  awk '
-    NR==FNR { files[$0]=1; next }
-    {
-      match($0, /^[^ ]+ +/)
-      filepath = substr($0, RSTART + RLENGTH)
-      if (!(filepath in files)) print
-    }
-  ' <(printf "%s\n" "${files_to_watch[@]}") "$lock_file" > "$tmp" 2>/dev/null || true
-  "$sha256_cmd" "${files_to_watch[@]}" >> "$tmp"
-  mv "$tmp" "$lock_file"
+  bazel_env_merge_lock "$sha256_cmd" "$lock_file" "${files_to_watch[@]}" || true
   BAZEL_ENV_INTERNAL_EXEC=True exec "$own_path" "$@"
 fi
 

--- a/launcher.sh.tpl
+++ b/launcher.sh.tpl
@@ -58,20 +58,24 @@ files_to_watch=()
 # Fall back to workspace_path if source_workspace_path is empty.
 watch_base="${source_workspace_path:-$workspace_path}"
 
-# Enumerate this tool's watched files via the shared helper so the launcher and
-# the status script (bazel run) agree on the exact contents of bazel_env.lock.
-source "${own_path}.runfiles/{{lock_lib_rlocation_path}}"
-
-while IFS= read -r _watch_file; do
-  files_to_watch+=("$_watch_file")
-done < <(bazel_env_collect_watch_files "$watch_base" \
-  "${own_dir}/__common_watch_dirs.txt" \
-  "${own_dir}/__common_watch_files.txt" \
-  "${own_dir}/_${own_name}_watch_dirs.txt" \
-  "${own_dir}/_${own_name}_watch_files.txt")
-
 rebuild_env=False
 sha256_cmd="${own_path}.runfiles/{{sha256sum_rlocation_path}}"
+
+# Enumerate this tool's watched files via the shared helper so the launcher and
+# the status script (bazel run) agree on the exact contents of bazel_env.lock.
+# Sourcing can fail if the runfiles tree is incomplete, 
+# treat that as staleness so the rebuild below repairs the runfiles tree.
+if source "${own_path}.runfiles/{{lock_lib_rlocation_path}}" 2>/dev/null; then
+  while IFS= read -r _watch_file; do
+    files_to_watch+=("$_watch_file")
+  done < <(bazel_env_collect_watch_files "$watch_base" \
+    "${own_dir}/__common_watch_dirs.txt" \
+    "${own_dir}/__common_watch_files.txt" \
+    "${own_dir}/_${own_name}_watch_dirs.txt" \
+    "${own_dir}/_${own_name}_watch_files.txt")
+else
+  rebuild_env=True
+fi
 
 if [[ ${#files_to_watch[@]} -gt 0 ]]; then
   lock_file="$watch_base/bazel_env.lock"
@@ -140,7 +144,9 @@ if [[ $rebuild_env == True && "${BAZEL_ENV_INTERNAL_EXEC:-False}" != True ]]; th
   # Run bazel from the source workspace to ensure it can find the WORKSPACE/MODULE file.
   # Redirect stdout to stderr so build logs don't pollute stdout and break piping.
   (cd "$watch_base" && "${BAZEL:-bazel}" build {{bazel_env_label}} >&2)
-  bazel_env_merge_lock "$sha256_cmd" "$lock_file" "${files_to_watch[@]}" || true
+  if [[ ${#files_to_watch[@]} -gt 0 ]]; then
+    bazel_env_merge_lock "$sha256_cmd" "$lock_file" "${files_to_watch[@]}" || true
+  fi
   BAZEL_ENV_INTERNAL_EXEC=True exec "$own_path" "$@"
 fi
 

--- a/lock_lib.sh
+++ b/lock_lib.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Shared helpers for bazel_env's watch-file lock, sourced by both the per-tool
+# launcher (launcher.sh.tpl) and the status script (status.sh.tpl).
+
+# bazel_env_collect_watch_files <watch_base> <list_file>...
+#
+# In:
+#   <watch_base>    workspace root the list entries are relative to.
+#   <list_file>...  *_watch_dirs.txt (dirs to watch) and/or *_watch_files.txt
+#                   (files to watch); missing list files are ignored.
+# Out (stdout):     every watched file as an absolute path, one per line,
+#                   sorted and de-duplicated (empty if none).
+bazel_env_collect_watch_files() {
+  local watch_base="$1"
+  shift
+  # Canonicalize (resolve symlinks) so launcher and status agree on paths.
+  if [[ -d "$watch_base" ]]; then
+    watch_base="$(cd "$watch_base" && pwd -P)"
+  fi
+  local list dir file
+  local out=()
+  for list in "$@"; do
+    [[ -f "$list" ]] || continue
+    case "$list" in
+    *_watch_dirs.txt)
+      for dir in $(cat "$list"); do
+        [[ -d "$watch_base/$dir" ]] || continue
+        while IFS= read -r file; do
+          out+=("$file")
+        done < <(find "$watch_base/$dir" -type f)
+      done
+      ;;
+    *_watch_files.txt)
+      for file in $(cat "$list"); do
+        [[ -f "$watch_base/$file" ]] && out+=("$watch_base/$file")
+      done
+      ;;
+    esac
+  done
+  [[ ${#out[@]} -gt 0 ]] || return 0
+  printf '%s\n' "${out[@]}" | sort -u
+}

--- a/lock_lib.sh
+++ b/lock_lib.sh
@@ -54,21 +54,17 @@ bazel_env_merge_lock() {
   local sha256_cmd="$1" lock_file="$2"
   shift 2
   [[ $# -gt 0 ]] || return 0
-  local tmp
-  tmp="$(mktemp "${lock_file}.XXXXXX")" || return 1
-  if [[ -f "$lock_file" ]]; then
-    if ! awk '
-      NR==FNR { seen[$0] = 1; next }
-      { match($0, /^[^ ]+ +/); p = substr($0, RSTART + RLENGTH); if (!(p in seen)) print }
-    ' <(printf '%s\n' "$@") "$lock_file" > "$tmp"; then
-      rm -f "$tmp"
-      return 1
+  # Run in a subshell so the cleanup trap is scoped here and never touches the caller's traps
+  (
+    tmp="$(mktemp "${lock_file}.XXXXXX")" || exit 1
+    trap 'rm -f "$tmp"' EXIT INT TERM
+    if [[ -f "$lock_file" ]]; then
+      awk '
+        NR==FNR { seen[$0] = 1; next }
+        { match($0, /^[^ ]+ +/); p = substr($0, RSTART + RLENGTH); if (!(p in seen)) print }
+      ' <(printf '%s\n' "$@") "$lock_file" > "$tmp" || exit 1
     fi
-  fi
-  if "$sha256_cmd" "$@" >> "$tmp"; then
-    mv "$tmp" "$lock_file" || { rm -f "$tmp"; return 1; }
-  else
-    rm -f "$tmp"
-    return 1
-  fi
+    "$sha256_cmd" "$@" >> "$tmp" || exit 1
+    mv "$tmp" "$lock_file"
+  )
 }

--- a/lock_lib.sh
+++ b/lock_lib.sh
@@ -40,3 +40,35 @@ bazel_env_collect_watch_files() {
   [[ ${#out[@]} -gt 0 ]] || return 0
   printf '%s\n' "${out[@]}" | sort -u
 }
+
+# bazel_env_merge_lock <sha256_cmd> <lock_file> <file>...
+#
+# In:
+#   <sha256_cmd>  sha256sum binary used to hash the files.
+#   <lock_file>   lock to update in place (workspace-global, shared by all targets).
+#   <file>...     absolute paths whose lock entries to refresh.
+# Out:            <lock_file> updated - these files' hashes refreshed, all other
+#                 entries kept. Atomic (temp + rename); left untouched on any
+#                 failure (returns non-zero).
+bazel_env_merge_lock() {
+  local sha256_cmd="$1" lock_file="$2"
+  shift 2
+  [[ $# -gt 0 ]] || return 0
+  local tmp
+  tmp="$(mktemp "${lock_file}.XXXXXX")" || return 1
+  if [[ -f "$lock_file" ]]; then
+    if ! awk '
+      NR==FNR { seen[$0] = 1; next }
+      { match($0, /^[^ ]+ +/); p = substr($0, RSTART + RLENGTH); if (!(p in seen)) print }
+    ' <(printf '%s\n' "$@") "$lock_file" > "$tmp"; then
+      rm -f "$tmp"
+      return 1
+    fi
+  fi
+  if "$sha256_cmd" "$@" >> "$tmp"; then
+    mv "$tmp" "$lock_file" || { rm -f "$tmp"; return 1; }
+  else
+    rm -f "$tmp"
+    return 1
+  fi
+}

--- a/status.sh.tpl
+++ b/status.sh.tpl
@@ -86,24 +86,12 @@ if [[ -x "$sha256_cmd" ]]; then
     watched+=("$_watch_file")
   done < <(bazel_env_collect_watch_files "$PWD" '{{tools_dir}}'/*_watch_dirs.txt '{{tools_dir}}'/*_watch_files.txt)
   if [[ ${#watched[@]} -gt 0 ]]; then
-    # Merge into the workspace-global lock instead of overwriting it: keep
-    # entries we don't manage - other bazel_env targets share this one lock -
-    # and refresh only our own watched files. Written via temp + mv so a partial
-    # write can't leave a truncated lock.
-    if _lock_tmp="$(mktemp bazel_env.lock.XXXXXX)"; then
-      if [[ -f bazel_env.lock ]]; then
-        awk '
-          NR==FNR { seen[$0] = 1; next }
-          { match($0, /^[^ ]+ +/); p = substr($0, RSTART + RLENGTH); if (!(p in seen)) print }
-        ' <(printf '%s\n' "${watched[@]}") bazel_env.lock > "$_lock_tmp" 2>/dev/null || true
-      fi
-      if "$sha256_cmd" "${watched[@]}" >> "$_lock_tmp"; then
-        mv "$_lock_tmp" bazel_env.lock
-        echo "✅ Refreshed bazel_env.lock"
-      else
-        rm -f "$_lock_tmp"
-        echo "⚠️ Failed to refresh bazel_env.lock" >&2
-      fi
+    # Merge into the workspace-global lock (shared by every bazel_env target):
+    # keep entries we don't manage, refresh only our own watched files.
+    if bazel_env_merge_lock "$sha256_cmd" bazel_env.lock "${watched[@]}"; then
+      echo "✅ Refreshed bazel_env.lock"
+    else
+      echo "⚠️ Failed to refresh bazel_env.lock" >&2
     fi
   fi
 else

--- a/status.sh.tpl
+++ b/status.sh.tpl
@@ -82,9 +82,15 @@ sha256_cmd="${RUNFILES_DIR:-$0.runfiles}/{{sha256sum_rlocation_path}}"
 if [[ -x "$sha256_cmd" ]]; then
   source "${RUNFILES_DIR:-$0.runfiles}/{{lock_lib_rlocation_path}}"
   watched=()
-  while IFS= read -r _watch_file; do
-    watched+=("$_watch_file")
-  done < <(bazel_env_collect_watch_files "$PWD" '{{tools_dir}}'/*_watch_dirs.txt '{{tools_dir}}'/*_watch_files.txt)
+  watch_lists=()
+  while IFS= read -r _rel; do
+    [[ -n "$_rel" ]] && watch_lists+=("${RUNFILES_DIR:-$0.runfiles}/$_rel")
+  done < <(printf '%s\n' '{{watch_list_rlocation_paths}}')
+  if [[ ${#watch_lists[@]} -gt 0 ]]; then
+    while IFS= read -r _watch_file; do
+      watched+=("$_watch_file")
+    done < <(bazel_env_collect_watch_files "$PWD" "${watch_lists[@]}")
+  fi
   if [[ ${#watched[@]} -gt 0 ]]; then
     # Merge into the workspace-global lock (shared by every bazel_env target):
     # keep entries we don't manage, refresh only our own watched files.

--- a/status.sh.tpl
+++ b/status.sh.tpl
@@ -77,6 +77,39 @@ EOF
     exit 1
 fi
 
+# regenerate bazel_env.lock
+sha256_cmd="${RUNFILES_DIR:-$0.runfiles}/{{sha256sum_rlocation_path}}"
+if [[ -x "$sha256_cmd" ]]; then
+  source "${RUNFILES_DIR:-$0.runfiles}/{{lock_lib_rlocation_path}}"
+  watched=()
+  while IFS= read -r _watch_file; do
+    watched+=("$_watch_file")
+  done < <(bazel_env_collect_watch_files "$PWD" '{{tools_dir}}'/*_watch_dirs.txt '{{tools_dir}}'/*_watch_files.txt)
+  if [[ ${#watched[@]} -gt 0 ]]; then
+    # Merge into the workspace-global lock instead of overwriting it: keep
+    # entries we don't manage - other bazel_env targets share this one lock -
+    # and refresh only our own watched files. Written via temp + mv so a partial
+    # write can't leave a truncated lock.
+    if _lock_tmp="$(mktemp bazel_env.lock.XXXXXX)"; then
+      if [[ -f bazel_env.lock ]]; then
+        awk '
+          NR==FNR { seen[$0] = 1; next }
+          { match($0, /^[^ ]+ +/); p = substr($0, RSTART + RLENGTH); if (!(p in seen)) print }
+        ' <(printf '%s\n' "${watched[@]}") bazel_env.lock > "$_lock_tmp" 2>/dev/null || true
+      fi
+      if "$sha256_cmd" "${watched[@]}" >> "$_lock_tmp"; then
+        mv "$_lock_tmp" bazel_env.lock
+        echo "✅ Refreshed bazel_env.lock"
+      else
+        rm -f "$_lock_tmp"
+        echo "⚠️ Failed to refresh bazel_env.lock" >&2
+      fi
+    fi
+  fi
+else
+  echo "⚠️ sha256sum not found in runfiles; skipped refreshing bazel_env.lock" >&2
+fi
+
 cat << 'EOF'
 
 Tools available in PATH:


### PR DESCRIPTION
**Context**

This PR builds upon https://github.com/buildbuddy-io/bazel_env.bzl/pull/76, which made tools rebuild lazily by comparing watched files against `bazel_env.lock`.

But that lock is only ever written as a side effect of the per-tool launcher. 
The first time you invoke a tool, the launcher sees no (or a stale) entry, prints `Detected changes in watched files, rebuilding bazel_env...`, rebuilds, and then writes the lock. 

In our monorepo, we expected `bazel run //:bazel_env` to refresh the env, and that using tools after it would not cause a rebuild.

---

**Proposed solution**

`bazel run //:bazel_env` now refreshes `bazel_env.lock`, so freshly built tools are not treated as stale on their first invocation.

The enumeration + write logic is migrated into a new `lock_lib.sh`, sourced by both the status script (`status.sh.tpl`) and the per-tool launcher (`launcher.sh.tpl`), so the two agree on the lock's contents:
  - `bazel_env_collect_watch_files` — resolves the `*_watch_dirs.txt / *_watch_files.txt` lists (introduced in #76) into a sorted, de-duplicated set of absolute paths.
  - `bazel_env_merge_lock` — hashes those paths and writes the lock atomically, leaving the existing lock untouched on any failure.

---

**Notes**

The lockfile still never prunes old entries. It is still append-only/merge with old entries.