### PR TITLE
launcher: rebuild when the tool's entry point no longer resolves

### DIFF
--- a/examples/bazel_env_test.sh
+++ b/examples/bazel_env_test.sh
@@ -312,3 +312,55 @@ if [[ "$(cat "$observation_file")" != "absent" ]]; then
   echo "Expected the launcher to delete $all_tools_out before invoking bazel, but it still existed"
   exit 1
 fi
+
+#### Auto-rebuild when a tool's entry point no longer resolves ####
+
+# A prebuilt wrapper can outlive the files its runfiles symlinks point at
+# (a bazel clean, Bazel 9's repo contents cache GC, external cache cleaners).
+# The launcher must detect the dangling entry point and trigger a rebuild
+# instead of exec'ing into a bare "No such file or directory".
+
+# bin/jq is a trampoline; the real launcher (and its runfiles) live under
+# tools/.
+jq_wrapper="$build_workspace_directory/bazel-out/bazel_env-opt/bin/bazel_env/tools/jq"
+# The entry point's rlocation path is baked into the wrapper as the subject of
+# its case statements; extract it rather than hardcoding the repo name
+# separator. The BASH_SOURCE case statement doesn't match: its subject
+# contains a '$'.
+jq_entry_point="$(sed -n 's/^case "\([^$]*\)" in$/\1/p' "$jq_wrapper" | head -n 1)"
+if [[ -z "$jq_entry_point" || ! -e "$jq_wrapper.runfiles/$jq_entry_point" ]]; then
+  echo "Failed to extract jq's entry point from its wrapper (got: '$jq_entry_point')"
+  exit 1
+fi
+mv "$jq_wrapper.runfiles/$jq_entry_point" "$jq_wrapper.runfiles/$jq_entry_point.hidden"
+
+dangling_marker=$(mktemp)
+trap 'rm -f "$rebuild_stdout" "$rebuild_stderr" "$rebuild_marker" "$observation_file" "$repair_marker" "$dangling_marker"' EXIT
+
+# The fake bazel cannot actually repair the runfiles, so the invocation still
+# fails — what matters is that the launcher diagnosed the dangling entry point
+# and attempted the rebuild.
+if dangling_output=$(env \
+    -u TEST_SRCDIR \
+    -u RUNFILES_DIR \
+    -u RUNFILES_MANIFEST_FILE \
+    FAKE_BAZEL_MARKER_FILE="$dangling_marker" \
+    BAZEL=./fake_bazel.sh \
+    PATH="$build_workspace_directory/bazel-out/bazel_env-opt/bin/bazel_env/bin:/bin:/usr/bin" \
+    jq --version 2>&1); then
+  echo "Expected jq to fail while its entry point is missing (the fake bazel cannot repair it), but it succeeded:"
+  echo "$dangling_output"
+  exit 1
+fi
+
+assert_contains "jq's entry point is missing from its runfiles (deleted by a Bazel clean or repo cache GC?), rebuilding bazel_env..." "$dangling_output"
+
+if [[ ! -s "$dangling_marker" ]]; then
+  echo "Expected the launcher to invoke bazel to repair the dangling entry point"
+  exit 1
+fi
+
+# With the entry point back (as the real bazel build would restore it), the
+# tool works again without a rebuild.
+mv "$jq_wrapper.runfiles/$jq_entry_point.hidden" "$jq_wrapper.runfiles/$jq_entry_point"
+assert_cmd_output "jq --version" "jq-1.7"

--- a/launcher.sh.tpl
+++ b/launcher.sh.tpl
@@ -129,10 +129,30 @@ if [[ ${#files_to_watch[@]} -gt 0 ]]; then
     rebuild_env=True
   fi
 fi
+watch_files_stale=$rebuild_env
+
+# The entry point resolves through absolute symlinks into Bazel's output base
+# and repo caches, which Bazel can delete out from under a previously built
+# tool (repo contents cache GC, a clean, external cache cleaners) — it cannot
+# see references held by prebuilt wrappers. Exec'ing would fail with a bare
+# "No such file or directory"; rebuild instead, which re-fetches the deleted
+# repos and makes the existing symlinks resolve again.
+case "{{rlocation_path}}" in
+  /*) entry_point="{{rlocation_path}}" ;;
+  *) entry_point="${own_path}.runfiles/{{rlocation_path}}" ;;
+esac
+entry_point_missing=False
+if [[ ! -e "$entry_point" ]]; then
+  entry_point_missing=True
+  rebuild_env=True
+fi
 
 if [[ $rebuild_env == True && "${BAZEL_ENV_INTERNAL_EXEC:-False}" != True ]]; then
-  echo "Detected changes in watched files, rebuilding bazel_env..." >&2
-  if [[ ${#files_to_watch[@]} -gt 0 ]]; then
+  if [[ $entry_point_missing == True ]]; then
+    echo "$own_name's entry point is missing from its runfiles (deleted by a Bazel clean or repo cache GC?), rebuilding bazel_env..." >&2
+  fi
+  if [[ $watch_files_stale == True ]]; then
+    echo "Detected changes in watched files, rebuilding bazel_env..." >&2
     echo "Changed files:" >&2
     for file in "${files_to_watch[@]}"; do
       if [[ -f "$file" ]]; then
@@ -164,18 +184,23 @@ if [[ $rebuild_env == True && "${BAZEL_ENV_INTERNAL_EXEC:-False}" != True ]]; th
   # Run bazel from the source workspace to ensure it can find the WORKSPACE/MODULE file.
   # Redirect stdout to stderr so build logs don't pollute stdout and break piping.
   (cd "$watch_base" && "${BAZEL:-bazel}" build {{bazel_env_label}} >&2)
-  tmp=$(mktemp)
-  trap 'rm -f "$tmp"' EXIT INT TERM
-  awk '
-    NR==FNR { files[$0]=1; next }
-    {
-      match($0, /^[^ ]+ +/)
-      filepath = substr($0, RSTART + RLENGTH)
-      if (!(filepath in files)) print
-    }
-  ' <(printf "%s\n" "${files_to_watch[@]}") "$lock_file" > "$tmp" 2>/dev/null || true
-  "$sha256_cmd" "${files_to_watch[@]}" >> "$tmp"
-  mv "$tmp" "$lock_file"
+  # A rebuild triggered by a missing entry point alone has no watched files, and
+  # then there is no lock file to refresh (and sha256sum with no arguments would
+  # hang reading stdin).
+  if [[ ${#files_to_watch[@]} -gt 0 ]]; then
+    tmp=$(mktemp)
+    trap 'rm -f "$tmp"' EXIT INT TERM
+    awk '
+      NR==FNR { files[$0]=1; next }
+      {
+        match($0, /^[^ ]+ +/)
+        filepath = substr($0, RSTART + RLENGTH)
+        if (!(filepath in files)) print
+      }
+    ' <(printf "%s\n" "${files_to_watch[@]}") "$lock_file" > "$tmp" 2>/dev/null || true
+    "$sha256_cmd" "${files_to_watch[@]}" >> "$tmp"
+    mv "$tmp" "$lock_file"
+  fi
   BAZEL_ENV_INTERNAL_EXEC=True exec "$own_path" "$@"
 fi
 


### PR DESCRIPTION
## The problem

A prebuilt wrapper's runfiles resolve through absolute symlinks into Bazel's output base and repo caches, and Bazel can delete those out from under a previously built `bazel_env` — a `bazel clean`, an external cache cleaner, and most commonly **Bazel 9's repo contents cache GC**, which reaps entries no invocation has used for `--repo_contents_cache_gc_max_age` (default 14d) and cannot see references held by prebuilt wrappers.

The wrapper then dies with a bare, misleading error:

```
bazel-out/bazel_env-opt/bin/tools/bazel_env/bin/python: line 203:
.../bin/python.runfiles/aspect_rules_py++python_interpreters+python_3_13_x86_64_unknown_linux_gnu/bin/python3:
No such file or directory
```

In practice this bites any checkout left idle for two weeks (the launcher runs before any `bazel` command gets a chance to re-fetch anything, e.g. from a direnv `.envrc` load, so the whole dev environment comes up broken), and the message points nowhere near the cause or fix.

## The fix

Before exec'ing, check that the baked-in entry point rlocation still resolves; if not, reuse the existing rebuild-and-reexec path. The `bazel build` re-fetches the deleted repos, which makes the existing symlinks resolve again — no lock-file change needed, so the rebuild happens exactly once.

Two supporting changes:

- The rebuild block's "Detected changes in watched files" message and changed-file listing are now printed only when watched files actually triggered the rebuild; the dangling-entry-point trigger prints its own diagnosis.
- The lock-file refresh is guarded for the new trigger: with zero watched files, `$lock_file` is unbound (under `set -u`) and `sha256sum` with no file arguments would hang reading stdin.

## Testing

Added an e2e case to `examples/bazel_env_test.sh`: hide `jq`'s entry point in its runfiles, assert the launcher diagnoses it and invokes (the fake) bazel, then restore it and assert the tool works again without a rebuild.

Also verified end-to-end against the real failure in a large monorepo on Bazel 9.1.1: with the interpreter repo's `external/` symlink dangling (simulating the GC) and a cold server, a single tool invocation prints the diagnosis, rebuilds in ~5s (re-fetching the repo), and execs successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)